### PR TITLE
Add option to use FASTA files with protein sequences as input

### DIFF
--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -330,6 +330,7 @@ def read_peptide_input(filename):
 
     '''expected columns (min required): id sequence'''
     with open(filename, 'r') as peptide_input:
+        csv.field_size_limit(600000)    # enable listing of protein names for each peptide 
         reader = csv.DictReader(peptide_input, delimiter='\t')
         for row in reader:
             pep = Peptide(row['sequence'])

--- a/bin/gen_peptides.py
+++ b/bin/gen_peptides.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+import sys
+import argparse
+import csv
+import pandas as pd
+from Bio import SeqIO
+from collections import Counter
+
+
+parser = argparse.ArgumentParser("Preprocessing of epitopes.")
+parser.add_argument('-i', '--input', metavar='FILE', type=str, help = 'TSV filename, containing paths to fasta files.')
+parser.add_argument('-o', '--output', metavar='FILE', type=argparse.FileType('w'), help='Output file: peptides.')
+parser.add_argument('-min', '--min_length', metavar='N', type=int, help='Min. length of peptides that will be generated.')
+parser.add_argument('-max', '--max_length', metavar='N', type=int, help='Max. length of peptides that will be generated.')
+args = parser.parse_args()
+
+
+# for each fasta file get proteins: Id and sequence
+def get_proteins(filename):
+    with open(filename, 'r') as fasta_file:
+        return [ (str(record.id), str(record.seq)) for record in SeqIO.parse(fasta_file, 'fasta') ]
+
+# for each file, get all proteins with id and sequence
+# not super efficient, but probably fine for now
+protid_protseq = pd.DataFrame(
+    [ (prot_id, prot_seq) for prot_id, prot_seq in get_proteins(args.input)  ],
+    columns = ['protein','sequence']
+    )
+
+
+####################
+# generate peptides
+def gen_peptides(prot_seq, k):
+    return [ prot_seq[i:(i+k)] for i in range(len(prot_seq)-k) ]
+
+# for each protein sequence, for each length k: generate all peptides
+prot_peptides = pd.DataFrame(
+    [ (it.protein, pep) for it in protid_protseq.itertuples() for k in range(args.min_length, args.max_length+1) for pep in gen_peptides(it.sequence, k) ],
+    columns = ['protein','peptides']
+    )
+# count occurences of each peptide in each protein
+prot_peptides = prot_peptides.groupby(['protein','peptides']).size().reset_index(name='count')
+# aggregate for each peptide: pep_id     pep_seq    prot1,prot2,..    3,6,..
+results = prot_peptides.groupby('peptides').agg(list)
+results = results.reset_index()
+results = results.assign(id=["pep_" + str(id) for id in results.index])
+# rename column names
+results.columns = ['sequence', 'proteins', 'counts', 'id'] 
+# convert to string and then joint to get rid of brackets and quotes
+results["proteins"] = results["proteins"].str.join(",") 
+results["counts"] = results["counts"].apply(lambda x : ','.join([ str(e) for e in  x]))
+results[['sequence','id','proteins','counts']].to_csv(args.output, sep="\t", index=False)

--- a/conf/base.config
+++ b/conf/base.config
@@ -42,6 +42,9 @@ process {
   withLabel:process_long {
     time = { check_max( 20.h * task.attempt, 'time' ) }
   }
+  withName:genPeptides {
+    container = 'nfcore/epitopeprediction-py3:dev'
+  }
   withName:get_software_versions {
     cache = false
   }

--- a/conf/test_proteins.config
+++ b/conf/test_proteins.config
@@ -1,0 +1,18 @@
+/*
+ * -------------------------------------------------
+ *  Nextflow config file for running tests
+ * -------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test. Use as follows:
+ *   nextflow run nf-core/epitopeprediction -profile test_proteins
+ */
+
+params {
+  max_cpus = 2
+  max_memory = 6.GB
+  max_time = 4.h
+
+  // Input data
+  peptides = 'https://github.com/nf-core/test-datasets/raw/epitopeprediction/testdata/proteins/proteins.tsv'
+  alleles = 'https://github.com/nf-core/test-datasets/raw/epitopeprediction/testdata/alleles/alleles.txt'
+}

--- a/containers/py3/Dockerfile
+++ b/containers/py3/Dockerfile
@@ -1,0 +1,13 @@
+FROM nfcore/base:1.9
+LABEL authors="Sabrina Krakau" \
+      description="Docker image containing python3 for gen_peptides.py in the  nf-core/epitopeprediction pipeline"
+
+# Install the conda environment
+COPY environment.yml /
+RUN conda env create -f /environment.yml && conda clean -a
+
+# Add conda installation dir to PATH (instead of doing 'conda activate')
+ENV PATH /opt/conda/envs/nf-core-epitopeprediction-py3-1.1.0dev/bin:$PATH
+
+# Dump the details of the installed packages to a file for posterity
+RUN conda env export --name nf-core-epitopeprediction-py3-1.1.0dev > nf-core-epitopeprediction-py3-1.1.0dev.yml

--- a/containers/py3/environment.yml
+++ b/containers/py3/environment.yml
@@ -1,0 +1,11 @@
+# You can use this file to create a conda environment for this pipeline:
+#   conda env create -f environment.yml
+name: nf-core-epitopeprediction-py3-1.1.0dev
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - python=3.7.3
+  - pandas=1.0.1
+  - biopython=1.74

--- a/main.nf
+++ b/main.nf
@@ -30,7 +30,9 @@ def helpMessage() {
 
     Alternative inputs:
       --peptides [file]             Path to TSV file containing peptide sequences (minimum required: id and sequence column)
-    
+      --proteins [file]             Path to FASTA file containing protein sequences
+
+
     Pipeline options:
       --filter_self [bool]          Specifies that peptides should be filtered against the specified human proteome references Default: false
       --wild_type  [bool]           Specifies that wild-type sequences of mutated peptides should be predicted as well Default: false
@@ -67,8 +69,9 @@ multiqc_config = file(params.multiqc_config)
 output_docs = file("$baseDir/docs/output.md")
 
 
-//Generate empty channels for peptides and variants
-ch_split_peptides = Channel.empty()
+//Generate empty channels for peptides, proteins and variants
+ch_peptides = Channel.empty()
+ch_proteins = Channel.empty()
 ch_split_variants = Channel.empty()
 
 
@@ -80,7 +83,16 @@ if ( params.peptides ) {
     Channel
         .fromPath(params.peptides)
         .ifEmpty { exit 1, "Peptide input not found: ${params.peptides}" }
-        .set { ch_split_peptides }
+        .set { ch_peptides }
+}
+else if ( params.proteins ) {
+    if ( params.wild_type ) {
+        exit 1, "Protein input not compatible with wild-type sequence generation."
+    }
+    Channel
+        .fromPath(params.proteins)
+        .ifEmpty { exit 1, "Protein input not found: ${params.proteins}" }
+        .set { ch_proteins }
 }
 else if (params.input) {
     Channel
@@ -89,7 +101,7 @@ else if (params.input) {
         .set { ch_split_variants }
 }
 else {
-    exit 1, "Please specify a file that contains annotated variants OR a file that contains peptide sequences."
+    exit 1, "Please specify a file that contains annotated variants, protein sequences OR peptide sequences."
 }
 
 if ( !params.alleles ) {
@@ -139,6 +151,7 @@ if ( params.alleles ) summary['Alleles'] = params.alleles
 summary['Max. Peptide Length'] = params.max_peptide_length
 summary['MHC Class'] = params.mhc_class
 if ( params.peptides ) summary['Peptides'] = params.peptides
+if ( params.proteins ) summary['Proteins'] = params.proteins
 summary['Reference Genome'] = params.genome
 if ( params.proteome ) summary['Reference proteome'] = params.proteome
 summary['Self-Filter'] = params.filter_self
@@ -250,8 +263,32 @@ process splitVariants {
     }
 }
 
+
 /*
- * STEP 1b - Split peptide data
+ * STEP 0b - Process FASTA files and generate peptides
+ */
+if (params.proteins) {
+    process genPeptides {
+        input:
+        file proteins from ch_proteins
+
+        output:
+        file 'peptides.tsv' into ch_split_peptides
+
+        when: !params.peptides
+
+        // TODO 
+        // for all peptid lengths
+        script:
+        """
+        gen_peptides.py --input ${proteins} --output 'peptides.tsv' --max_length ${params.max_peptide_length} --min_length ${params.min_peptide_length}
+        """
+    }
+ } else {
+    ch_peptides.set{ch_split_peptides}
+ }
+/*
+ * STEP 1b- Split peptide data
  */
 process splitPeptides {
     input:
@@ -285,7 +322,7 @@ process peptidePrediction {
    file "*.json" into ch_json_reports
    
    script:
-   def input_type = params.peptides ? "--peptides ${inputs}" : "--somatic_mutations ${inputs}"
+   def input_type = params.peptides ? "--peptides ${inputs}" : params.proteins ?  "--peptides ${inputs}" : "--somatic_mutations ${inputs}"
    def ref_prot = params.proteome ? "--proteome ${params.proteome}" : ""
    def wt = params.wild_type ? "--wild_type" : ""
    """

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,6 +12,7 @@ params {
   filter_self = false
   mhc_class = 1
   peptides = false
+  proteins = false
   max_peptide_length = (mhc_class == 1) ? 11 : 16
   min_peptide_length = (mhc_class == 1) ? 8 : 15
   tools = 'syfpeithi'


### PR DESCRIPTION
Since I didn't want to write python2 scripts, I added a container for python3 ;) would that be OK?
The FASTA file is processed and peptides with the chosen lengths are generated from all sequences. Unique peptides together with a list of proteins in which they occur as well as a list with corresponding counts are stored and used for epitope prediction. For now only one FASTA file is supported as input.

I called the input parameter `--proteins`. Maybe we want to change the name of the `--proteome` parameter (used for self-filtering), since this might be a bit confusing?

#
Many thanks for contributing to nf-core/epitopeprediction!

Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

## PR checklist
 - [ ] This comment contains a description of changes (with reason)
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [x] If necessary, also make a PR on the [nf-core/epitopeprediction branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/epitopeprediction)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md
