### PR TITLE
Added software versions for Fred2 and MHCnuggets.

### DIFF
--- a/bin/scrape_software_versions.py
+++ b/bin/scrape_software_versions.py
@@ -9,7 +9,9 @@ regexes = {
     'MultiQC': ['v_multiqc.txt', r"multiqc, version (\S+)"],
     'CSVTK': ['v_csvtk.txt', r"csvtk v(\S+)"],
     'SNPsift': ['v_snpsift.txt', r"SnpSift version (\S+)"],
+    'Fred2': ['v_fred2.txt', r"fred2 (\S+)"],
     'MHCFlurry': ['v_mhcflurry.txt', r"mhcflurry (\S+)"],
+    'MHCnuggets': ['v_mhcnuggets.txt', r"mhcnuggets (\S+)"],
 }
 
 results = OrderedDict()
@@ -18,7 +20,9 @@ results['Nextflow'] = '<span style="color:#999999;\">N/A</span>'
 results['MultiQC'] = '<span style="color:#999999;\">N/A</span>'
 results['CSVTK'] = '<span style="color:#999999;\">N/A</span>'
 results['SNPsift'] = '<span style="color:#999999;\">N/A</span>'
+results['Fred2'] = '<span style="color:#999999;\">N/A</span>'
 results['MHCFlurry'] = '<span style="color:#999999;\">N/A</span>'
+results['MHCnuggets'] = '<span style="color:#999999;\">N/A</span>'
 
 # Search each file using its regex
 for k, v in regexes.items():

--- a/main.nf
+++ b/main.nf
@@ -216,7 +216,9 @@ process get_software_versions {
     multiqc --version > v_multiqc.txt
     csvtk version > v_csvtk.txt
     echo \$(SnpSift 2>&1) > v_snpsift.txt
+    python -c "import pkg_resources; print 'fred2 ' + pkg_resources.get_distribution('Fred2').version" > v_fred2.txt
     echo \$(mhcflurry-predict --version 2>&1) > v_mhcflurry.txt
+    python -c "import pkg_resources; print 'mhcnuggets ' + pkg_resources.get_distribution('mhcnuggets').version" > v_mhcnuggets.txt
     scrape_software_versions.py &> software_versions_mqc.yaml
     """
 }


### PR DESCRIPTION
 Added versions for Fred2 and MHCnuggets to `get_software_versions()` (#37). We will need that to control the used Fred2 predictor classes. 

#
Many thanks for contributing to nf-core/epitopeprediction!

Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/epitopeprediction branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/epitopeprediction)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md
