### PR TITLE
Adjusted test for mouse allele to use mhcnuggets

### DIFF
--- a/conf/test_peptides_h2.config
+++ b/conf/test_peptides_h2.config
@@ -15,4 +15,6 @@ params {
   // Input data
   peptides = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/peptides/peptides.tsv'
   alleles = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/alleles/alleles.H2.txt'
+
+  tools = 'mhcnuggets-class-1'
 }


### PR DESCRIPTION
Changed `test_peptides_h2` to use `mhcnuggets-class-1` instead of `syfpeithi`, since Fred2 v2.0.7 does not yet support mouse alleles for Syfpeithi (Syfpeithi itself does).

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/epitopeprediction branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/epitopeprediction)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md
