### PR TITLE
Fix predictions with multiple methods, small improvements

### DIFF
--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -825,7 +825,7 @@ def make_predictions_from_variants(variants_all, methods, alleles, minlength, ma
             if ('HLA-' in str(c)) or ('H-2-' in str(c)):
                 idx = df.columns.get_loc(c)
                 df.insert(idx + 1, '%s affinity' % c, df.apply(lambda x: create_affinity_values(str(c), int(x['length']), float(x[c]), x['Method'], max_values_matrices, allele_string_map), axis=1))
-                df.insert(idx + 2, '%s binder' % c, df.apply(lambda x: bool(create_binder_values(float(x['%s affinity' % c]), x['Method'])), axis=1))
+                df.insert(idx + 2, '%s binder' % c, df.apply(lambda x: create_binder_values(float(x['%s affinity' % c]), x['Method']), axis=1))
                 df = df.rename(columns={c: '%s score' % c})
                 df['%s score' % c] = df.apply(lambda x: create_score_values(float(x['%s score' % c]), x['Method']), axis=1)
 


### PR DESCRIPTION
The problem was the merging process of the method-specific prediction result data frames when using multiple prediction tools. Using the `panda` method `concat` seems to solve the problem. However, so far I am not sure why the code didn't work anymore.

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/epitopeprediction branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/epitopeprediction)
 - [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [x] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md
