### PR TITLE
Use additional metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
+- [#59](https://github.com/nf-core/epitopeprediction/pull/59) - Parse and store metadata dynamically for variant data
 - [#50](https://github.com/nf-core/epitopeprediction/pull/50) - Change parameter to specify the genome version to `--genome_version` ( `--genome` deprecated)
 - [#50](https://github.com/nf-core/epitopeprediction/pull/50) - Merge template updates (`v1.10.1`, and `v1.10.2`)
 - [#47](https://github.com/nf-core/epitopeprediction/pull/47) - Update `FRED2` to version 2.0.7

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -214,19 +214,14 @@ def read_vcf(filename, pass_only=True):
     # get lists of additional metadata
     metadata_list = set(vcf_reader.infos.keys()) - set(exclusion_list)
     metadata_list.update(set(inclusion_list))
-
     format_list = set(vcf_reader.formats.keys())
+    final_metadata_list = []
 
     dict_vars = {}
     list_vars = []
     transcript_ids = []
     genotye_dict = {"het": False, "hom": True, "ref": True}
-
-    # should we add metadata to the report?
-    #logger.info(vcf_reader.metadata.keys())
-
-    final_metadata_list = []
-
+    
     for num, record in enumerate(vl):
         c = record.CHROM.strip('chr')
         p = record.POS - 1
@@ -324,6 +319,16 @@ def read_vcf(filename, pass_only=True):
                         if metadata_name in record.INFO:
                             final_metadata_list.append(metadata_name)
                             var.log_metadata(metadata_name, record.INFO[metadata_name])
+                    
+                    for sample in record.samples:
+                        for format_key in format_list:
+                            format_header = '{}.{}'.format(sample.sample, format_key)
+                            final_metadata_list.append(format_header)
+                            if isinstance(sample[format_key], list):
+                                format_value = ','.join([str(i) for i in sample[format_key]])
+                            else:
+                                format_value = sample[format_key]
+                            var.log_metadata(format_header, format_value)
                     dict_vars[var] = var
                     list_vars.append(var)
 


### PR DESCRIPTION
This should add functionality to add metadata provided with variants dynamically without being limited to a set of (hardcoded) metadata fields. Which information from VCF files should we store and write to the results table? Currently, the information from the `INFO` column is used but we could additionally store the genotype-specific information, e.g. in the following line that would be the information given for `NORMAL` and `TUMOR`.

```
#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NORMAL	TUMOR
chr1	12954870	.	C	T	.	PASS	NT=ref;QSS=52;QSS_NT=52;SGT=CC->CT;SOMATIC;TQSS=1;TQSS_NT=1;ANN=T|missense_variant|MODERATE|PRAMEF10|ENSG00000187545|transcript|ENST00000235347|protein_coding|3/4|c.413G>A|p.Cys138Tyr|493/1525|413/1425|138/474||	DP:FDP:SDP:SUBDP:AU:CU:GU:TU	414:0:0:0:0,0:413,425:0,0:1,4	8:0:0:0:0,0:3,4:0,0:5,9
```


## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/epitopeprediction branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/epitopeprediction)
 - [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [x] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md
