### PR TITLE
Fix link to zenodo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.1.0 - 2020-10-09
+## v1.1.0 - Morgenstelle - 2020-10-20
 
 ### `Added`
 


### PR DESCRIPTION
The link to zenodo was broken.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
- [ ] If necessary, also make a PR on the [nf-core/epitopeprediction branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/epitopeprediction)
