### PR TITLE
Make alleles channels value channels

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -121,8 +121,7 @@ if ( !params.show_supported_models ){
         exit 1, "Please specify a file containing MHC alleles."
     }
     else {
-        ch_alleles = Channel.fromPath(params.alleles, checkIfExists: true)
-        (ch_alleles, ch_check_alleles) = ch_alleles.into(2)
+        Channel.value(file(params.alleles, checkIfExists: true)).into{ch_alleles; ch_check_alleles}
     }
 
     if ( params.input ){


### PR DESCRIPTION
`ch_alleles` and `ch_check_alleles` being queue channels causes the pipeline to process only one chunk in the `peptidePrediction` process. Fix attached.

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
- [ ] If necessary, also make a PR on the [nf-core/epitopeprediction branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/epitopeprediction)
