### PR TITLE
Add support for the non-free netMHC tool family

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,17 +52,51 @@ jobs:
       - name: Run pipeline with test data
         run: |
           nextflow run ${GITHUB_WORKSPACE} -profile test,docker
-
-  profile:
-      name: Run profile tests
+#
+#  profile:
+#      name: Run profile tests
+#      if: ${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/epitopeprediction') }}
+#      runs-on: ubuntu-latest
+#      env:
+#        NXF_VER: '20.04.0'
+#        NXF_ANSI_LOG: false
+#      strategy:
+#        matrix:
+#          tests: ['test_variant_tsv', 'test_peptides', 'test_peptides_h2', 'test_proteins', 'test_mhcnuggets', 'test_mhcflurry']
+#      steps:
+#        - name: Check out pipeline code
+#          uses: actions/checkout@v2
+#
+#        - name: Check if Dockerfile or Conda environment changed
+#          uses: technote-space/get-diff-action@v4
+#          with:
+#            FILES: |
+#              Dockerfile
+#              environment.yml
+#        - name: Build new docker image
+#          if: env.MATCHED_FILES
+#          run: docker build --no-cache . -t nfcore/epitopeprediction:1.1.0
+#
+#        - name: Pull docker image
+#          if: ${{ !env.MATCHED_FILES }}
+#          run: |
+#            docker pull nfcore/epitopeprediction:dev
+#            docker tag nfcore/epitopeprediction:dev nfcore/epitopeprediction:1.1.0
+#        - name: Install Nextflow
+#          run: |
+#            wget -qO- get.nextflow.io | bash
+#            sudo mv nextflow /usr/local/bin/
+#        - name: Run pipeline with profile ${{ matrix.tests }}
+#          run: |
+#            nextflow run ${GITHUB_WORKSPACE} -profile ${{ matrix.tests }},docker
+#
+  nonfree:
+      name: Run non-free tests
       if: ${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/epitopeprediction') }}
       runs-on: ubuntu-latest
       env:
         NXF_VER: '20.04.0'
         NXF_ANSI_LOG: false
-      strategy:
-        matrix:
-          tests: ['test_variant_tsv', 'test_peptides', 'test_peptides_h2', 'test_proteins', 'test_mhcnuggets', 'test_mhcflurry']
       steps:
         - name: Check out pipeline code
           uses: actions/checkout@v2
@@ -73,6 +107,14 @@ jobs:
             FILES: |
               Dockerfile
               environment.yml
+        - name: Install non-free software
+          env:
+            DECRYPT_PASSPHRASE: ${{ secrets.TEST_NETMHC }}
+            DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+            DOCKERHUB_PASS: ${{ secrets.DOCKERHUB_PASS }}
+          run: |
+            mkdir -v non-free
+            curl -L https://raw.githubusercontent.com/lkuchenb/test-datasets/epitopeprediction/software/non-free-software.tar.gpg | ${GITHUB_WORKSPACE}/bin/decrypt | tar -C non-free -v -x
         - name: Build new docker image
           if: env.MATCHED_FILES
           run: docker build --no-cache . -t nfcore/epitopeprediction:1.1.0
@@ -86,6 +128,15 @@ jobs:
           run: |
             wget -qO- get.nextflow.io | bash
             sudo mv nextflow /usr/local/bin/
-        - name: Run pipeline with profile ${{ matrix.tests }}
+        - name: Run pipeline with NetMHC
           run: |
-            nextflow run ${GITHUB_WORKSPACE} -profile ${{ matrix.tests }},docker
+            nextflow run ${GITHUB_WORKSPACE} -profile netmhc,docker
+        - name: Run pipeline with NetMHCII
+          run: |
+            nextflow run ${GITHUB_WORKSPACE} -profile netmhcii,docker
+        - name: Run pipeline with NetMHCpan
+          run: |
+            nextflow run ${GITHUB_WORKSPACE} -profile netmhcpan,docker
+        - name: Run pipeline with NetMHCIIpan
+          run: |
+            nextflow run ${GITHUB_WORKSPACE} -profile netmhciipan,docker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.2.0dev
+
+### `Added`
+
+- [#71](https://github.com/nf-core/epitopeprediction/pull/71) - Add support for the non-free netmhc tool family
+
 ## v1.1.0 - Morgenstelle - 2020-10-20
 
 ### `Added`

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The nf-core/epitopeprediction pipeline comes with documentation about the pipeli
 
 ## Credits
 
-nf-core/epitopeprediction was originally written by [Christopher Mohr](https://github.com/christopher-mohr) from [Institute for Translational Bioinformatics](https://kohlbacherlab.org/team_tbi/) and [Quantitative Biology Center](https://uni-tuebingen.de/forschung/forschungsinfrastruktur/zentrum-fuer-quantitative-biologie-qbic/) and [Alexander Peltzer](https://github.com/apeltzer) from [Böhringer Ingelheim](https://www.boehringer-ingelheim.de). Further contributions were made by [Sabrina Krakau](https://github.com/skrakau) from [Quantitative Biology Center](https://uni-tuebingen.de/forschung/forschungsinfrastruktur/zentrum-fuer-quantitative-biologie-qbic/).
+nf-core/epitopeprediction was originally written by [Christopher Mohr](https://github.com/christopher-mohr) from [Institute for Translational Bioinformatics](https://kohlbacherlab.org/team_tbi/) and [Quantitative Biology Center](https://uni-tuebingen.de/forschung/forschungsinfrastruktur/zentrum-fuer-quantitative-biologie-qbic/) and [Alexander Peltzer](https://github.com/apeltzer) from [Böhringer Ingelheim](https://www.boehringer-ingelheim.de). Further contributions were made by [Sabrina Krakau](https://github.com/skrakau) from [Quantitative Biology Center](https://uni-tuebingen.de/forschung/forschungsinfrastruktur/zentrum-fuer-quantitative-biologie-qbic/) and [Leon Kuchenbecker](https://github.com/lkuchenb) from the [Kohlbacher Lab](https://kohlbacherlab.org/).
 
 ## Contributions and Support
 

--- a/bin/decrypt
+++ b/bin/decrypt
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Decrypts stdin -> stdout reading the passphrase from the environment variable
+# DECRYPT_PASSPHRASE.
+gpg \
+	--quiet \
+	--batch \
+	--yes \
+	--decrypt \
+	--passphrase="$DECRYPT_PASSPHRASE" \
+	--output -

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -1011,7 +1011,7 @@ def __main__():
         # NOTE this needs to be updated, if a newer version will be available via Fred2 and should be used in the future
         tool_version.append(('syfpeithi', '1.0'))
         # get for each selected method the corresponding tool version
-        methods = { method:version for tool, version in tool_version for method in selected_methods if tool.lower() in method.lower() }
+        methods = { method.lower() : version for tool, version in tool_version for method in selected_methods if tool.lower() in method.lower() }
 
     for method, version in methods.items():
         if version not in EpitopePredictorFactory.available_methods()[method]:
@@ -1038,7 +1038,7 @@ def __main__():
 
     # replace method names with method names with version
     # complete_df.replace({'method': methods}, inplace=True)
-    complete_df['method'] = complete_df['method'].apply(lambda x : x + '-' + methods[x] )
+    complete_df['method'] = complete_df['method'].apply(lambda x : x.lower() + '-' + methods[x.lower()] )
 
     # include wild type sequences to dataframe if specified
     if args.wild_type:

--- a/bin/scrape_software_versions.py
+++ b/bin/scrape_software_versions.py
@@ -12,6 +12,10 @@ regexes = {
     'Fred2': ['v_fred2.txt', r"fred2 (\S+)"],
     'MHCFlurry': ['v_mhcflurry.txt', r"mhcflurry (\S+)"],
     'MHCnuggets': ['v_mhcnuggets.txt', r"mhcnuggets (\S+)"],
+    'NetMHC': ['v_netmhc.txt', r"netmhc (\S+)"],
+    'NetMHCpan': ['v_netmhcpan.txt', r"netmhcpan (\S+)"],
+    'NetMHCII': ['v_netmhcii.txt', r"netmhcii (\S+)"],
+    'NetMHCIIpan': ['v_netmhciipan.txt', r"netmhciipan (\S+)"],
 }
 
 results = OrderedDict()
@@ -23,6 +27,10 @@ results['SNPsift'] = '<span style="color:#999999;\">N/A</span>'
 results['Fred2'] = '<span style="color:#999999;\">N/A</span>'
 results['MHCFlurry'] = '<span style="color:#999999;\">N/A</span>'
 results['MHCnuggets'] = '<span style="color:#999999;\">N/A</span>'
+results['NetMHC'] = '<span style="color:#999999;\">N/A</span>'
+results['NetMHCpan'] = '<span style="color:#999999;\">N/A</span>'
+results['NetMHCII'] = '<span style="color:#999999;\">N/A</span>'
+results['NetMHCIIpan'] = '<span style="color:#999999;\">N/A</span>'
 
 # Search each file using its regex
 for k, v in regexes.items():

--- a/conf/test_netmhc.conf
+++ b/conf/test_netmhc.conf
@@ -1,0 +1,21 @@
+/*
+ * -------------------------------------------------
+ *  Nextflow config file for running tests
+ * -------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test. Use as follows:
+ *   nextflow run nf-core/epitopeprediction -profile test_peptides,<docker/singularity>
+ */
+
+params {
+  max_cpus = 2
+  max_memory = 6.GB
+  max_time = 48.h
+
+  // Input data
+  peptides = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/peptides/peptides.tsv'
+  alleles = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/alleles/alleles.txt'
+
+  tools = 'netmhc'
+  netmhc_path = './non-free/netmhc.tar.gz'
+}

--- a/conf/test_netmhcii.conf
+++ b/conf/test_netmhcii.conf
@@ -1,0 +1,21 @@
+/*
+ * -------------------------------------------------
+ *  Nextflow config file for running tests
+ * -------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test. Use as follows:
+ *   nextflow run nf-core/epitopeprediction -profile test_peptides,<docker/singularity>
+ */
+
+params {
+  max_cpus = 2
+  max_memory = 6.GB
+  max_time = 48.h
+
+  // Input data
+  peptides = 'https://raw.githubusercontent.com/lkuchenb/test-datasets/epitopeprediction/testdata/peptides/peptides_MHC_II.txt'
+  alleles = 'https://raw.githubusercontent.com/lkuchenb/test-datasets/epitopeprediction/testdata/alleles/alleles.DRB1_01_01.txt'
+
+  tools = 'netmhcii'
+  netmhcii_path = './non-free/netmhcii.tar.Z'
+}

--- a/conf/test_netmhciipan.conf
+++ b/conf/test_netmhciipan.conf
@@ -1,0 +1,21 @@
+/*
+ * -------------------------------------------------
+ *  Nextflow config file for running tests
+ * -------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test. Use as follows:
+ *   nextflow run nf-core/epitopeprediction -profile test_peptides,<docker/singularity>
+ */
+
+params {
+  max_cpus = 2
+  max_memory = 6.GB
+  max_time = 48.h
+
+  // Input data
+  peptides = 'https://raw.githubusercontent.com/lkuchenb/test-datasets/epitopeprediction/testdata/peptides/peptides_MHC_II.txt'
+  alleles = 'https://raw.githubusercontent.com/lkuchenb/test-datasets/epitopeprediction/testdata/alleles/alleles.DRB1_01_01.txt'
+
+  tools = 'netmhciipan'
+  netmhciipan_path = './non-free/netmhciipan.tar.gz'
+}

--- a/conf/test_netmhcpan.conf
+++ b/conf/test_netmhcpan.conf
@@ -1,0 +1,21 @@
+/*
+ * -------------------------------------------------
+ *  Nextflow config file for running tests
+ * -------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test. Use as follows:
+ *   nextflow run nf-core/epitopeprediction -profile test_peptides,<docker/singularity>
+ */
+
+params {
+  max_cpus = 2
+  max_memory = 6.GB
+  max_time = 48.h
+
+  // Input data
+  peptides = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/peptides/peptides.tsv'
+  alleles = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/alleles/alleles.txt'
+
+  tools = 'netmhcpan'
+  netmhcpan_path = './non-free/netmhcpan.tar.gz'
+}

--- a/main.nf
+++ b/main.nf
@@ -37,9 +37,15 @@ def helpMessage() {
       --mhc_class [1,2]                     Specifies whether the predictions should be done for MHC class I (1) or class II (2). Default: 1
       --max_peptide_length [int]            Specifies the maximum peptide length (not applied when '--peptides' is specified). Default: MHC class I: 11 aa, MHC class II: 16 aa
       --min_peptide_length [int]            Specifies the minimum peptide length (not applied when '--peptides' is specified). Default: MCH class I: 8 aa, MHC class II: 15 aa
-      --tools [str]                         Specifies a list of tool(s) to use. Available are: 'syfpeithi', 'mhcflurry', 'mhcnuggets-class-1', 'mhcnuggets-class-2'. Can be combined in a list separated by comma.
+      --tools [str]                         Specifies a list of tool(s) to use. Available are: 'syfpeithi', 'mhcflurry', 'mhcnuggets-class-1', 'mhcnuggets-class-2', 'netmhc', 'netmhcpan', 'netmhcii', 'netmhciipan'. Can be combined in a list separated by comma.
       --peptides_split_maxchunks [int]      Used in combination with '--peptides' or '--proteins': maximum number of peptide chunks that will be created for parallelization. Default: 100
       --peptides_split_minchunksize [int]   Used in combination with '--peptides' or '--proteins': minimum number of peptides that should be written into one chunk. Default: 5000
+
+    External software:
+      --netmhcpan_path                      To use the 'netmhcpan' tool, specify a path to the original NetMHCpan 4.1 tar.gz archive here.
+      --netmhc_path                         To use the 'netmhc' tool, specify a path to the original NetMHC 4.0 tar.gz archive here.
+      --netmhciipan_path                    To use the 'netmhciipan' tool, specify a path to the original NetMHCIIpan 4.0 tar.gz archive here.
+      --netmhcii_path                       To use the 'netmhcii' tool, specify a path to the original NetMHCII 2.3 tar.gz archive here.
 
     References                              If not specified in the configuration file or you wish to overwrite any of the references
       --genome_version [str]                Specifies the ensembl reference genome version (GRCh37, GRCh38) Default: GRCh37
@@ -79,6 +85,41 @@ ch_check_alleles = Channel.empty()
 
 // Store input base name for later
 def input_base_name = ''
+
+ch_nonfree_paths = Channel.create()
+
+netmhc_meta = [
+    netmhc : [
+        version      : "4.0",
+        software_md5 : "132dc322da1e2043521138637dd31ebf",
+        data_url     : "http://www.cbs.dtu.dk/services/NetMHC-4.0/data.tar.gz",
+        data_md5     : "63c646fa0921d617576531396954d633",
+        binary_name  : "netMHC"
+    ],
+    netmhcpan: [
+        version      : "4.0",
+        software_md5 : "94aa60f3dfd9752881c64878500e58f3",
+        data_url     : "http://www.cbs.dtu.dk/services/NetMHCpan-4.0/data.Linux.tar.gz",
+        data_md5     : "26cbbd99a38f6692249442aeca48608f",
+        binary_name  : "netMHCpan"
+    ],
+    netmhcii: [
+        version      : "2.2",
+        software_md5 : "918b7108a37599887b0725623d0974e6",
+        data_url     : "http://www.cbs.dtu.dk/services/NetMHCII-2.2/data.tar.gz",
+        data_md5     : "11579b61d3bfe13311f7b42fc93b4dd8",
+        binary_name  : "netMHCII"
+    ],
+    netmhciipan: [
+        version      : "3.1",
+        software_md5 : "0962ce799f7a4c9631f8566a55237073",
+        data_url     : "http://www.cbs.dtu.dk/services/NetMHCIIpan-3.1/data.tar.gz",
+        data_md5     : "f833df245378e60ca6e55748344a36f6",
+        binary_name  : "netMHCIIpan"
+    ]
+]
+
+tools = params.tools?.tokenize(',')
 
 // Validating parameters
 if ( !params.show_supported_models ){
@@ -137,7 +178,7 @@ if ( !params.show_supported_models ){
         exit 1, "Invalid MHC class option: ${params.mhc_class}. Valid options: 1, 2"
     }
 
-    if ( (params.mhc_class == 1 && params.tools.contains("mhcnuggets-class-2")) || (params.mhc_class == 2 && params.tools.contains("mhcnuggets-class-1")) ){
+    if ( (params.mhc_class == 1 && tools.contains("mhcnuggets-class-2")) || (params.mhc_class == 2 && tools.contains("mhcnuggets-class-1")) ){
         log.warn "Provided MHC class is not compatible with the selected MHCnuggets tool. Output might be empty.\n"
     }
 
@@ -149,6 +190,38 @@ if ( !params.show_supported_models ){
     {
         exit 1, "Invalid memory mode parameter: ${params.mem_mode}. Valid options: 'low', 'intermediate', 'high'."
     }
+
+    // External tools
+    ["netmhc", "netmhcpan", "netmhcii", "netmhciipan"].each {
+        // Check if the _path parameter was set for this tool
+        if (params["${it}_path"] as Boolean && ! tools.contains(it))
+        {
+            log.warn("--${it}_path specified, but --tools does not contain ${it} have to be both specified to enable ${it}. Ignoring.")
+        }
+        else if (!params["${it}_path"] as Boolean && tools.contains(it))
+        {
+            log.warn("--${it}_path not specified, but --tools contains ${it} have to be both specified to enable ${it}. Ignoring.")
+            tools.removeElement(it)
+        }
+        else if (params["${it}_path"])
+        {
+            // If so, add the tool name and user installation path to the external tools import channel
+            ch_nonfree_paths.bind([
+                it,
+                netmhc_meta[it].version,
+                netmhc_meta[it].software_md5,
+                file(params["${it}_path"], checkIfExists:true),
+                file(netmhc_meta[it].data_url),
+                netmhc_meta[it].data_md5,
+                netmhc_meta[it].binary_name
+            ])
+        }
+    }
+    if (tools.isEmpty())
+    {
+        exit 1, "No valid tools specified."
+    }
+    ch_nonfree_paths.close()
 }
 
 // Has the run name been specified by the user?
@@ -199,7 +272,7 @@ if ( params.show_supported_models ) {
     if ( !params.peptides && !params.proteins ) summary['Reference Genome'] = params.genome_version
     if ( params.proteome ) summary['Reference Proteome'] = params.proteome
     summary['Self-Filter'] = params.filter_self
-    summary['Tools'] = params.tools
+    summary['Tools'] = tools.join(',')
     summary['Wild-types'] = params.wild_type
     summary['Protein FASTA Output'] = params.fasta_output
     if ( params.peptides || params.proteins ) summary['Max. Number of Chunks for Parallelization'] = params.peptides_split_maxchunks
@@ -250,6 +323,68 @@ Channel.from(summary.collect{ [it.key, it.value] })
     .set { ch_workflow_summary }
 
 /*
+ * Copy non-free software provided by the user into the working directory
+ */
+process netmhc_tools_import {
+    input:
+    tuple val(toolname), val(toolversion), val(toolchecksum), path(tooltarball), file(datatarball), val(datachecksum), val(toolbinaryname) from ch_nonfree_paths
+
+    output:
+    path "${toolname}" into ch_nonfree_tools
+    path "v_${toolname}.txt" into ch_nonfree_versions
+
+    script:
+    """
+    #
+    # CHECK IF THE PROVIDED SOFTWARE TARBALL IS A REGULAR FILES
+    #
+    if [ ! -f "$tooltarball" ]; then
+        echo "Path specified for ${toolname} does not point to a regular file. Please specify a path to the original tool tarball." >&2
+        exit 1
+    fi
+
+    #
+    # VALIDATE THE CHECKSUM OF THE PROVIDED SOFTWARE TARBALL
+    #
+    checksum="\$(md5sum "$tooltarball" | cut -f1 -d' ')"
+    if [ "\$checksum" != "${toolchecksum}" ]; then
+        echo "Checksum error for $toolname. Please make sure to provide the original tarball for $toolname version $toolversion" >&2
+        exit 2
+    fi
+
+    #
+    # UNPACK THE PROVIDED SOFTWARE TARBALL
+    #
+    mkdir -v "${toolname}"
+    tar -C "${toolname}" --strip-components 1 -x -f "$tooltarball"
+
+    #
+    # MODIFY THE NETMHC WRAPPER SCRIPT SO THAT IT FINDS ITS OWN LOCATION
+    #
+    sed -i.bak -e "s_/scratch_/tmp_" -e "s_setenv[[:space:]]NMHOME.*_setenv NMHOME \\`realpath -s \\\$0 | sed -r 's/[^/]+\$//'\\`_" "${toolname}/${toolbinaryname}"
+
+    #
+    # VALIDATE THE CHECKSUM OF THE DOWNLOADED MODEL DATA
+    #
+    checksum="\$(md5sum "$datatarball" | cut -f1 -d' ')"
+    if [ "\$checksum" != "${datachecksum}" ]; then
+        echo "A checksum mismatch occurred when checking the data file for ${toolname}." >&2
+        exit 3
+    fi
+
+    #
+    # UNPACK THE DOWNLOADED MODEL DATA
+    #
+    tar -C "${toolname}" -v -x -f "$datatarball"
+
+    #
+    # CREATE VERSION FILE
+    #
+    echo "${toolname} ${toolversion}" > "v_${toolname}.txt"
+    """
+}
+
+/*
  * Parse software version numbers
  */
 process get_software_versions {
@@ -258,6 +393,8 @@ process get_software_versions {
                       if (filename.indexOf(".csv") > 0) filename
                       else null
                 }
+    input:
+    file ("*") from ch_nonfree_versions.collect().ifEmpty([])
 
     output:
     file 'software_versions_mqc.yaml' into ch_software_versions_yaml
@@ -317,7 +454,7 @@ process checkRequestedModels {
     check_requested_models.py ${input_type} \
                          --alleles ${alleles} \
                          --mhcclass ${params.mhc_class} \
-                         --tools ${params.tools} \
+                         --tools ${tools.join(",")} \
                          --versions ${software_versions} > model_warnings.log
     """
 }
@@ -410,12 +547,13 @@ process peptidePrediction {
    file inputs from ch_splitted_vcfs.flatten().mix(ch_splitted_tsvs.flatten(), ch_splitted_gsvars.flatten(), ch_splitted_peptides.flatten())
    file alleles from ch_alleles
    file software_versions from ch_software_versions_csv
+   file ('nonfree_software/*') from ch_nonfree_tools.collect().ifEmpty([])
 
    output:
    file "*.tsv" into ch_predicted_peptides
    file "*.json" into ch_json_reports
    file "*.fasta" optional true into ch_protein_fastas
-   
+
    script:
    def input_type = params.peptides ? "--peptides ${inputs}" : params.proteins ?  "--peptides ${inputs}" : "--somatic_mutations ${inputs}"
    def ref_prot = params.proteome ? "--proteome ${params.proteome}" : ""
@@ -428,12 +566,17 @@ process peptidePrediction {
    # specify MHCflurry release for which to download models, need to be updated here as well when MHCflurry will be updated
    export MHCFLURRY_DOWNLOADS_CURRENT_RELEASE=1.4.0
 
+   # Add non-free software to the PATH
+   shopt -s nullglob
+   for p in nonfree_software/*; do export PATH="\$(realpath -s "\$p"):\$PATH"; done
+   shopt -u nullglob
+
    epaa.py ${input_type} --identifier ${inputs.baseName} \
                          --alleles $alleles \
                          --mhcclass ${params.mhc_class} \
                          --max_length ${params.max_peptide_length} \
                          --min_length ${params.min_peptide_length} \
-                         --tools ${params.tools} \
+                         --tools ${tools.join(",")} \
                          --versions ${software_versions} \
                          --reference ${params.genome_version} \
                          ${ref_prot} \

--- a/nextflow.config
+++ b/nextflow.config
@@ -22,6 +22,10 @@ params {
   peptides_split_maxchunks = 100
   peptides_split_minchunksize = 5000
   show_supported_models = false
+  netmhcpan_path = false
+  netmhc_path = false
+  netmhciipan_path = false
+  netmhcii_path = false
 
   // Additional annotation files
   proteome = ''

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -180,6 +180,34 @@
                 }
             }
         },
+	"external_software":{
+	  "title": "External software",
+	  "type" : "object",
+	  "description" : "External software that is not shipped with the pipeline.",
+	  "default": "",
+	  "properties" : {
+	    "netmhcpan_path" : {
+	      "type" : "string",
+	      "default" : "",
+	      "description" : "To use the 'netmhcpan' tool, specify the original software tarball for NetMHCpan 4.0 (Linux) here."
+	    },
+	    "netmhc_path" : {
+	      "type" : "string",
+	      "default" : "",
+	      "description" : "To use the 'netmhc' tool, specify the original software tarball for NetMHC 4.0 (Linux) here."
+	    },
+	    "netmhciipan_path" : {
+	      "type" : "string",
+	      "default" : "",
+	      "description" : "To use the 'netmhciipan' tool, specify the original software tarball for NetMHCIIpan 3.1 (Linux) here."
+	    },
+	    "netmhcii_path" : {
+	      "type" : "string",
+	      "default" : "",
+	      "description" : "To use the 'netmhcii' tool, specify the original software tarball for NetMHCII 2.2 (Linux) here."
+	    }
+	  }
+	},
         "generic_options": {
             "title": "Generic options",
             "type": "object",
@@ -359,6 +387,9 @@
         },
         {
             "$ref": "#/definitions/run_optimisation"
+        },
+        {
+            "$ref": "#/definitions/external_software"
         },
         {
             "$ref": "#/definitions/generic_options"


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
- [ ] If necessary, also make a PR on the [nf-core/epitopeprediction branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/epitopeprediction)

## Additions

This patch adds support for the non-free 3rd party tools NetMHC, NetMHCpan, NetMHCII and NetMHCIIpan. Since the tools' licenses do not allow for redistribution of the software, the user has to provide the software tarball which can be obtained from the upstream website.

* To maintain reproducibility, the pipeline validates the checksum of the provided software tarballs
* The patch provides a process that
  * Unpacks the software tarballs
  * Performs necessary modifications to the tools wrapper scripts as required by the installation instructions
  * Downloads the model data as required by installation instructions. Again, checksums are being checked.

## Changes

* `epaa.py`: Make tool name comparison case insensitive. Unfortunately, the method names aren't uniform w.r.t. upper / lower case letters among the netMHC family of tools.
* `main.nf`: Convert `params.tools` to a groovy list before parsing. The previous `.contains()` calls were applied on strings, which worked fine for the previously used tools, but since e.g. `netmhc` is a substring of `netmhcpan` it would clash with the newly added tools