### PR TITLE
Add support for the non-free netMHC tool family

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
             nextflow run ${GITHUB_WORKSPACE} -profile ${{ matrix.tests }},docker
 
   nonfree:
-      name: Run non-free tests
+      name: Run NetMHC tool family tests
       if: ${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/epitopeprediction') }}
       runs-on: ubuntu-latest
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,53 @@ jobs:
         - name: Run pipeline with profile ${{ matrix.tests }}
           run: |
             nextflow run ${GITHUB_WORKSPACE} -profile ${{ matrix.tests }},docker
+
+  nonfree:
+      name: Run non-free tests
+      if: ${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/epitopeprediction') }}
+      runs-on: ubuntu-latest
+      env:
+        NXF_VER: '20.04.0'
+        NXF_ANSI_LOG: false
+      steps:
+        - name: Check out pipeline code
+          uses: actions/checkout@v2
+
+        - name: Install non-free software
+          env:
+            DECRYPT_PASSPHRASE: ${{ secrets.TEST_NETMHC }}
+          run: |
+            mkdir -v non-free
+            curl -L https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/software/non-free-software.tar.gpg | ${GITHUB_WORKSPACE}/bin/decrypt | tar -C non-free -v -x
+
+        - name: Check if Dockerfile or Conda environment changed
+          uses: technote-space/get-diff-action@v4
+          with:
+            FILES: |
+              Dockerfile
+              environment.yml
+        - name: Build new docker image
+          if: env.MATCHED_FILES
+          run: docker build --no-cache . -t nfcore/epitopeprediction:dev
+
+        - name: Pull docker image
+          if: ${{ !env.MATCHED_FILES }}
+          run: |
+            docker pull nfcore/epitopeprediction:dev
+            docker tag nfcore/epitopeprediction:dev nfcore/epitopeprediction:dev
+        - name: Install Nextflow
+          run: |
+            wget -qO- get.nextflow.io | bash
+            sudo mv nextflow /usr/local/bin/
+        - name: Run pipeline with NetMHC
+          run: |
+            nextflow run ${GITHUB_WORKSPACE} -profile test_netmhc,docker
+        - name: Run pipeline with NetMHCII
+          run: |
+            nextflow run ${GITHUB_WORKSPACE} -profile test_netmhcii,docker
+        - name: Run pipeline with NetMHCpan
+          run: |
+            nextflow run ${GITHUB_WORKSPACE} -profile test_netmhcpan,docker
+        - name: Run pipeline with NetMHCIIpan
+          run: |
+            nextflow run ${GITHUB_WORKSPACE} -profile test_netmhciipan,docker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v1.2.0dev
 
+### `Added`
+
+- [#73](https://github.com/nf-core/epitopeprediction/pull/73) - Add support for the non-free netmhc tool family
+
 ## v1.1.0 - Morgenstelle - 2020-10-20
 
 ### `Added`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
-- [#73](https://github.com/nf-core/epitopeprediction/pull/73) - Add support for the non-free netmhc tool family
+- [#73](https://github.com/nf-core/epitopeprediction/pull/73) - Add support for the non-free netmhc tool family including netMHC 4.0, netMHCpan 4.0, netMHCII 2.2, and netMHCIIpan 3.1
 
 ## v1.1.0 - Morgenstelle - 2020-10-20
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The nf-core/epitopeprediction pipeline comes with documentation about the pipeli
 
 ## Credits
 
-nf-core/epitopeprediction was originally written by [Christopher Mohr](https://github.com/christopher-mohr) from [Institute for Translational Bioinformatics](https://kohlbacherlab.org/team_tbi/) and [Quantitative Biology Center](https://uni-tuebingen.de/forschung/forschungsinfrastruktur/zentrum-fuer-quantitative-biologie-qbic/) and [Alexander Peltzer](https://github.com/apeltzer) from [Böhringer Ingelheim](https://www.boehringer-ingelheim.de). Further contributions were made by [Sabrina Krakau](https://github.com/skrakau) from [Quantitative Biology Center](https://uni-tuebingen.de/forschung/forschungsinfrastruktur/zentrum-fuer-quantitative-biologie-qbic/).
+nf-core/epitopeprediction was originally written by [Christopher Mohr](https://github.com/christopher-mohr) from [Institute for Translational Bioinformatics](https://kohlbacherlab.org/team_tbi/) and [Quantitative Biology Center](https://uni-tuebingen.de/forschung/forschungsinfrastruktur/zentrum-fuer-quantitative-biologie-qbic/) and [Alexander Peltzer](https://github.com/apeltzer) from [Böhringer Ingelheim](https://www.boehringer-ingelheim.de). Further contributions were made by [Sabrina Krakau](https://github.com/skrakau) from [Quantitative Biology Center](https://uni-tuebingen.de/forschung/forschungsinfrastruktur/zentrum-fuer-quantitative-biologie-qbic/) and [Leon Kuchenbecker](https://github.com/lkuchenb) from the [Kohlbacher Lab](https://kohlbacherlab.org/).
 
 ## Contributions and Support
 

--- a/bin/decrypt
+++ b/bin/decrypt
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Decrypts stdin -> stdout reading the passphrase from the environment variable
+# DECRYPT_PASSPHRASE.
+gpg \
+	--quiet \
+	--batch \
+	--yes \
+	--decrypt \
+	--passphrase="$DECRYPT_PASSPHRASE" \
+	--output -

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -1011,7 +1011,7 @@ def __main__():
         # NOTE this needs to be updated, if a newer version will be available via Fred2 and should be used in the future
         tool_version.append(('syfpeithi', '1.0'))
         # get for each selected method the corresponding tool version
-        methods = { method:version for tool, version in tool_version for method in selected_methods if tool.lower() in method.lower() }
+        methods = { method.lower() : version for tool, version in tool_version for method in selected_methods if tool.lower() in method.lower() }
 
     for method, version in methods.items():
         if version not in EpitopePredictorFactory.available_methods()[method]:
@@ -1038,7 +1038,7 @@ def __main__():
 
     # replace method names with method names with version
     # complete_df.replace({'method': methods}, inplace=True)
-    complete_df['method'] = complete_df['method'].apply(lambda x : x + '-' + methods[x] )
+    complete_df['method'] = complete_df['method'].apply(lambda x : x.lower() + '-' + methods[x.lower()] )
 
     # include wild type sequences to dataframe if specified
     if args.wild_type:

--- a/bin/scrape_software_versions.py
+++ b/bin/scrape_software_versions.py
@@ -12,6 +12,10 @@ regexes = {
     'Fred2': ['v_fred2.txt', r"fred2 (\S+)"],
     'MHCFlurry': ['v_mhcflurry.txt', r"mhcflurry (\S+)"],
     'MHCnuggets': ['v_mhcnuggets.txt', r"mhcnuggets (\S+)"],
+    'NetMHC': ['v_netmhc.txt', r"netmhc (\S+)"],
+    'NetMHCpan': ['v_netmhcpan.txt', r"netmhcpan (\S+)"],
+    'NetMHCII': ['v_netmhcii.txt', r"netmhcii (\S+)"],
+    'NetMHCIIpan': ['v_netmhciipan.txt', r"netmhciipan (\S+)"],
 }
 
 results = OrderedDict()
@@ -23,6 +27,10 @@ results['SNPsift'] = '<span style="color:#999999;\">N/A</span>'
 results['Fred2'] = '<span style="color:#999999;\">N/A</span>'
 results['MHCFlurry'] = '<span style="color:#999999;\">N/A</span>'
 results['MHCnuggets'] = '<span style="color:#999999;\">N/A</span>'
+results['NetMHC'] = '<span style="color:#999999;\">N/A</span>'
+results['NetMHCpan'] = '<span style="color:#999999;\">N/A</span>'
+results['NetMHCII'] = '<span style="color:#999999;\">N/A</span>'
+results['NetMHCIIpan'] = '<span style="color:#999999;\">N/A</span>'
 
 # Search each file using its regex
 for k, v in regexes.items():

--- a/conf/test_netmhc.config
+++ b/conf/test_netmhc.config
@@ -1,0 +1,24 @@
+/*
+ * -------------------------------------------------
+ *  Nextflow config file for running tests
+ * -------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test. Use as follows:
+ *   nextflow run nf-core/epitopeprediction -profile test_netmhc,<docker/singularity>
+ */
+
+params {
+  config_profile_name = 'NetMHC Test Profile'
+  config_profile_description = 'Peptide list based test profile for NetMHC'
+
+  max_cpus = 2
+  max_memory = 6.GB
+  max_time = 48.h
+
+  // Input data
+  peptides = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/peptides/peptides.tsv'
+  alleles = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/alleles/alleles.txt'
+
+  tools = 'netmhc'
+  netmhc_path = './non-free/netmhc.tar.gz'
+}

--- a/conf/test_netmhcii.config
+++ b/conf/test_netmhcii.config
@@ -1,0 +1,24 @@
+/*
+ * -------------------------------------------------
+ *  Nextflow config file for running tests
+ * -------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test. Use as follows:
+ *   nextflow run nf-core/epitopeprediction -profile test_netmhcii,<docker/singularity>
+ */
+
+params {
+  config_profile_name = 'NetMHCII Test Profile'
+  config_profile_description = 'Peptide list based test profile for NetMHCII'
+
+  max_cpus = 2
+  max_memory = 6.GB
+  max_time = 48.h
+
+  // Input data
+  peptides = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/peptides/peptides_MHC_II.txt'
+  alleles = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/alleles/alleles.DRB1_01_01.txt'
+
+  tools = 'netmhcii'
+  netmhcii_path = './non-free/netmhcii.tar.Z'
+}

--- a/conf/test_netmhciipan.config
+++ b/conf/test_netmhciipan.config
@@ -1,0 +1,24 @@
+/*
+ * -------------------------------------------------
+ *  Nextflow config file for running tests
+ * -------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test. Use as follows:
+ *   nextflow run nf-core/epitopeprediction -profile test_netmhciipan,<docker/singularity>
+ */
+
+params {
+  config_profile_name = 'NetMHCIIpan Test Profile'
+  config_profile_description = 'Peptide list based test profile for NetMHCIIpan'
+
+  max_cpus = 2
+  max_memory = 6.GB
+  max_time = 48.h
+
+  // Input data
+  peptides = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/peptides/peptides_MHC_II.txt'
+  alleles = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/alleles/alleles.DRB1_01_01.txt'
+
+  tools = 'netmhciipan'
+  netmhciipan_path = './non-free/netmhciipan.tar.gz'
+}

--- a/conf/test_netmhcpan.config
+++ b/conf/test_netmhcpan.config
@@ -1,0 +1,24 @@
+/*
+ * -------------------------------------------------
+ *  Nextflow config file for running tests
+ * -------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test. Use as follows:
+ *   nextflow run nf-core/epitopeprediction -profile test_netmhcpan,<docker/singularity>
+ */
+
+params {
+  config_profile_name = 'NetMHCpan Test Profile'
+  config_profile_description = 'Peptide list based test profile for NetMHCpan'
+
+  max_cpus = 2
+  max_memory = 6.GB
+  max_time = 48.h
+
+  // Input data
+  peptides = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/peptides/peptides.tsv'
+  alleles = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/alleles/alleles.txt'
+
+  tools = 'netmhcpan'
+  netmhcpan_path = './non-free/netmhcpan.tar.gz'
+}

--- a/docs/output.md
+++ b/docs/output.md
@@ -45,10 +45,7 @@ The prediction results are given as allele-specific score and affinity values pe
   * **Affinity**: Calculated based on the score as the percentage of the maximum value of the corresponding matrix: `score(peptide) divided by the maximum score of the allele/length-specific matrix * 100`.
   * **Score**: Sum of the values given by the allele-specific position-specific scoring matrix (PSSM) for the respective peptide sequence.
 Peptides are considered binders if the affinity is higher than 50.
-* [`MHCflurry`](https://github.com/openvax/mhcflurry):
-  * **Affinity**: Predicted IC50 (threshold for binders: `<500 nmol/L`).
-  * **Score**: The provided score is calculated from the log-transformed predicted binding affinity and scaled to an interval of 0 to 1:  `1-log50000(aff)`.
-* [`MHCnuggets`](https://github.com/KarchinLab/mhcnuggets):
+* [`MHCflurry`](https://github.com/openvax/mhcflurry), [`MHCnuggets`](https://github.com/KarchinLab/mhcnuggets) and [`NetMHC` tool family](https://services.healthtech.dtu.dk/):
   * **Affinity**: Predicted IC50 (threshold for binders: `<500 nmol/L`).
   * **Score**: The provided score is calculated from the log-transformed predicted binding affinity and scaled to an interval of 0 to 1:  `1-log50000(aff)`.
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -22,6 +22,10 @@ params {
   peptides_split_maxchunks = 100
   peptides_split_minchunksize = 5000
   show_supported_models = false
+  netmhcpan_path = false
+  netmhc_path = false
+  netmhciipan_path = false
+  netmhcii_path = false
 
   // Additional annotation files
   proteome = ''

--- a/nextflow.config
+++ b/nextflow.config
@@ -99,6 +99,10 @@ profiles {
   test_proteins { includeConfig 'conf/test_proteins.config' }
   test_mhcnuggets { includeConfig 'conf/test_mhcnuggets.config' }
   test_mhcflurry { includeConfig 'conf/test_mhcflurry.config' }
+  test_netmhc { includeConfig 'conf/test_netmhc.config' }
+  test_netmhcii { includeConfig 'conf/test_netmhcii.config' }
+  test_netmhcpan { includeConfig 'conf/test_netmhcpan.config' }
+  test_netmhciipan { includeConfig 'conf/test_netmhciipan.config' }
   test_full { includeConfig 'conf/test_full.config' }
 }
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -183,28 +183,28 @@
 	"external_software":{
 	  "title": "External software",
 	  "type" : "object",
-	  "description" : "External software that is not shipped with the pipeline.",
+	  "description" : "External MHC binding prediction software that is not shipped with the pipeline.",
 	  "default": "",
 	  "properties" : {
 	    "netmhcpan_path" : {
 	      "type" : "string",
 	      "default" : "",
-	      "description" : "To use the 'netmhcpan' tool, specify the original software tarball for NetMHCpan 4.0 (Linux) here."
+	      "description" : "To use the 'netmhcpan' tool, specify the path to the original software tarball for NetMHCpan 4.0 (Linux) here."
 	    },
 	    "netmhc_path" : {
 	      "type" : "string",
 	      "default" : "",
-	      "description" : "To use the 'netmhc' tool, specify the original software tarball for NetMHC 4.0 (Linux) here."
+	      "description" : "To use the 'netmhc' tool, specify the path to the original software tarball for NetMHC 4.0 (Linux) here."
 	    },
 	    "netmhciipan_path" : {
 	      "type" : "string",
 	      "default" : "",
-	      "description" : "To use the 'netmhciipan' tool, specify the original software tarball for NetMHCIIpan 3.1 (Linux) here."
+	      "description" : "To use the 'netmhciipan' tool, specify the path to the original software tarball for NetMHCIIpan 3.1 (Linux) here."
 	    },
 	    "netmhcii_path" : {
 	      "type" : "string",
 	      "default" : "",
-	      "description" : "To use the 'netmhcii' tool, specify the original software tarball for NetMHCII 2.2 (Linux) here."
+	      "description" : "To use the 'netmhcii' tool, specify the path to the original software tarball for NetMHCII 2.2 (Linux) here."
 	    }
 	  }
 	},

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -180,6 +180,34 @@
                 }
             }
         },
+	"external_software":{
+	  "title": "External software",
+	  "type" : "object",
+	  "description" : "External software that is not shipped with the pipeline.",
+	  "default": "",
+	  "properties" : {
+	    "netmhcpan_path" : {
+	      "type" : "string",
+	      "default" : "",
+	      "description" : "To use the 'netmhcpan' tool, specify the original software tarball for NetMHCpan 4.0 (Linux) here."
+	    },
+	    "netmhc_path" : {
+	      "type" : "string",
+	      "default" : "",
+	      "description" : "To use the 'netmhc' tool, specify the original software tarball for NetMHC 4.0 (Linux) here."
+	    },
+	    "netmhciipan_path" : {
+	      "type" : "string",
+	      "default" : "",
+	      "description" : "To use the 'netmhciipan' tool, specify the original software tarball for NetMHCIIpan 3.1 (Linux) here."
+	    },
+	    "netmhcii_path" : {
+	      "type" : "string",
+	      "default" : "",
+	      "description" : "To use the 'netmhcii' tool, specify the original software tarball for NetMHCII 2.2 (Linux) here."
+	    }
+	  }
+	},
         "generic_options": {
             "title": "Generic options",
             "type": "object",
@@ -359,6 +387,9 @@
         },
         {
             "$ref": "#/definitions/run_optimisation"
+        },
+        {
+            "$ref": "#/definitions/external_software"
         },
         {
             "$ref": "#/definitions/generic_options"


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason)
- [x] `CHANGELOG.md` is updated
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Documentation in `docs` is updated
- [x] If necessary, also make a PR on the [nf-core/epitopeprediction branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/epitopeprediction)

## Additions

This patch adds support for the non-free 3rd party tools NetMHC, NetMHCpan, NetMHCII and NetMHCIIpan. Since the tools' licenses do not allow for redistribution of the software, the user has to provide the software tarball which can be obtained from the upstream website.

* To maintain reproducibility, the pipeline validates the checksum of the provided software tarballs
* The patch provides a process that
  * Unpacks the software tarballs
  * Performs necessary modifications to the tools wrapper scripts as required by the installation instructions
  * Downloads the model data as required by installation instructions. Again, checksums are being checked.

## Changes

* `epaa.py`: Make tool name comparison case insensitive. Unfortunately, the method names aren't uniform w.r.t. upper / lower case letters among the netMHC family of tools.
* `main.nf`: Convert `params.tools` to a groovy list before parsing. The previous `.contains()` calls were applied on strings, which worked fine for the previously used tools, but since e.g. `netmhc` is a substring of `netmhcpan` it would clash with the newly added tools