### PR TITLE
Customizable tool thresholds #80

### DIFF
--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -729,14 +729,21 @@ def create_affinity_values(allele, length, j, method, max_scores, allele_strings
         return np.nan
 
 
-def create_binder_values(aff, method):
+def create_binder_values(aff, method, thresholds):
     if not pd.isnull(aff):
-        if 'syf' in method:
-            return True if aff > 50.0 else False
-        else:
-            return True if aff <= 500.0 else False
+        return True if aff > thresholds.get(method) else False
     else:
         return np.nan
+
+
+def assign_tool_thresholds(methods, tool_thresholds):
+    tts = tool_thresholds.split(',')
+    if len(methods.keys()) != len(tts):
+        raise ValueError("Number of tools does not match number of thresholds")
+    else:
+        thresholds = {m: float(tt) for m, tt in zip(methods.keys(), tts)}
+        return thresholds
+
 
 def generate_wt_seqs(peptides):
     wt_dict = {}
@@ -779,7 +786,7 @@ def generate_wt_seqs(peptides):
     return wt_dict
 
 
-def make_predictions_from_variants(variants_all, methods, alleles, minlength, maxlength, martsadapter, protein_db, identifier, metadata, transcriptProteinMap):
+def make_predictions_from_variants(variants_all, methods, tool_thresholds, alleles, minlength, maxlength, martsadapter, protein_db, identifier, metadata, transcriptProteinMap):
     # list for all peptides and filtered peptides
     all_peptides = []
     all_peptides_filtered = []
@@ -847,7 +854,7 @@ def make_predictions_from_variants(variants_all, methods, alleles, minlength, ma
             if ('HLA-' in str(c)) or ('H-2-' in str(c)):
                 idx = df.columns.get_loc(c)
                 df.insert(idx + 1, '%s affinity' % c, df.apply(lambda x: create_affinity_values(str(c), int(x['length']), float(x[c]), x['Method'], max_values_matrices, allele_string_map), axis=1))
-                df.insert(idx + 2, '%s binder' % c, df.apply(lambda x: create_binder_values(float(x['%s affinity' % c]), x['Method']), axis=1))
+                df.insert(idx + 2, '%s binder' % c, df.apply(lambda x: create_binder_values(float(x['%s affinity' % c]), x['Method'], tool_thresholds), axis=1))
                 df = df.rename(columns={c: '%s score' % c})
                 df['%s score' % c] = df.apply(lambda x: create_score_values(float(x['%s score' % c]), x['Method']), axis=1)
 
@@ -863,7 +870,7 @@ def make_predictions_from_variants(variants_all, methods, alleles, minlength, ma
     return pred_dataframes, statistics, all_peptides_filtered, prots
 
 
-def make_predictions_from_peptides(peptides, methods, alleles, protein_db, identifier, metadata):
+def make_predictions_from_peptides(peptides, methods, tool_thresholds, alleles, protein_db, identifier, metadata):
     # dictionaries for syfpeithi matrices max values and allele mapping
     max_values_matrices = {}
     allele_string_map = {}
@@ -926,7 +933,7 @@ def make_predictions_from_peptides(peptides, methods, alleles, protein_db, ident
             if ('HLA-' in str(c)) or ('H-2-' in str(c)):
                 idx = df.columns.get_loc(c)
                 df.insert(idx + 1, '%s affinity' % c, df.apply(lambda x: create_affinity_values(str(c), int(x['length']), float(x[c]), x['Method'], max_values_matrices, allele_string_map), axis=1))
-                df.insert(idx + 2, '%s binder' % c, df.apply(lambda x: create_binder_values(float(x['%s affinity' % c]), x['Method']), axis=1))
+                df.insert(idx + 2, '%s binder' % c, df.apply(lambda x: create_binder_values(float(x['%s affinity' % c]), x['Method'], tool_thresholds), axis=1))
                 df = df.rename(columns={c: '%s score' % c})
                 df['%s score' % c] = df.apply(lambda x: create_score_values(float(x['%s score' % c]), x['Method']), axis=1)
 
@@ -949,6 +956,7 @@ def __main__():
     parser.add_argument('-l', "--max_length", help="Maximum peptide length")
     parser.add_argument('-ml', "--min_length", help="Minimum peptide length")
     parser.add_argument('-t', "--tools", help="Tools used for peptide predictions", required=True, type=str)
+    parser.add_argument('-tt', "--tool_thresholds", help="Customizable affinity threshold of given tools", required=False, type=str)
     parser.add_argument('-sv', "--versions", help="File containing parsed software version numbers.", required=True)
     parser.add_argument('-a', "--alleles", help="<Required> MHC Alleles", required=True)
     parser.add_argument('-r', "--reference", help="Reference, retrieved information will be based on this ensembl version", required=False, default='GRCh37', choices=['GRCh37', 'GRCh38'])
@@ -1017,17 +1025,19 @@ def __main__():
         if version not in EpitopePredictorFactory.available_methods()[method]:
             raise ValueError("The specified version " + version + " for " + method + " is not supported by Fred2.")
 
+    thresholds = assign_tool_thresholds(methods, args.tool_thresholds)
+
     # MHC class I or II predictions
     if args.mhcclass is 1:
         if args.peptides:
-            pred_dataframes, statistics = make_predictions_from_peptides(peptides, methods, alleles, up_db, args.identifier, metadata)
+            pred_dataframes, statistics = make_predictions_from_peptides(peptides, methods, thresholds, alleles, up_db, args.identifier, metadata)
         else:
-            pred_dataframes, statistics, all_peptides_filtered, proteins = make_predictions_from_variants(vl, methods, alleles, int(args.min_length), int(args.max_length) + 1, ma, up_db, args.identifier, metadata, transcriptProteinMap)
+            pred_dataframes, statistics, all_peptides_filtered, proteins = make_predictions_from_variants(vl, methods, thresholds, alleles, int(args.min_length), int(args.max_length) + 1, ma, up_db, args.identifier, metadata, transcriptProteinMap)
     else:
         if args.peptides:
-            pred_dataframes, statistics = make_predictions_from_peptides(peptides, methods, alleles, up_db, args.identifier, metadata)
+            pred_dataframes, statistics = make_predictions_from_peptides(peptides, methods, thresholds, alleles, up_db, args.identifier, metadata)
         else:
-            pred_dataframes, statistics, all_peptides_filtered, proteins = make_predictions_from_variants(vl, methods, alleles, int(args.min_length), int(args.max_length) + 1, ma, up_db, args.identifier, metadata, transcriptProteinMap)
+            pred_dataframes, statistics, all_peptides_filtered, proteins = make_predictions_from_variants(vl, methods, thresholds, alleles, int(args.min_length), int(args.max_length) + 1, ma, up_db, args.identifier, metadata, transcriptProteinMap)
 
     # concat dataframes for all peptide lengths
     try:

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -731,7 +731,10 @@ def create_affinity_values(allele, length, j, method, max_scores, allele_strings
 
 def create_binder_values(aff, method, thresholds):
     if not pd.isnull(aff):
-        return True if aff > thresholds.get(method) else False
+        if 'syf' in method:
+            return True if aff > thresholds[method] else False
+        else:
+            return True if aff < thresholds[method] else False
     else:
         return np.nan
 
@@ -1025,7 +1028,15 @@ def __main__():
         if version not in EpitopePredictorFactory.available_methods()[method]:
             raise ValueError("The specified version " + version + " for " + method + " is not supported by Fred2.")
 
-    thresholds = assign_tool_thresholds(methods, args.tool_thresholds)
+    thresholds = {"syfpeithi":50, "mhcflurry":500, "mhcnuggets-class-1":500, "mhcnuggets-class-2":500}
+    if args.tool_thresholds:
+        with open(args.tool_thresholds, 'r') as json_file:
+            threshold_file = json.load(json_file)
+            for tool,thresh in threshold_file.items():
+                if tool in thresholds.keys():
+                    thresholds[tool] = thresh
+                else:
+                    raise ValueError('Tool ' + tool +' in specified threshold file is not supported')
 
     # MHC class I or II predictions
     if args.mhcclass is 1:

--- a/main.nf
+++ b/main.nf
@@ -38,6 +38,7 @@ def helpMessage() {
       --max_peptide_length [int]            Specifies the maximum peptide length (not applied when '--peptides' is specified). Default: MHC class I: 11 aa, MHC class II: 16 aa
       --min_peptide_length [int]            Specifies the minimum peptide length (not applied when '--peptides' is specified). Default: MCH class I: 8 aa, MHC class II: 15 aa
       --tools [str]                         Specifies a list of tool(s) to use. Available are: 'syfpeithi', 'mhcflurry', 'mhcnuggets-class-1', 'mhcnuggets-class-2', 'netmhc', 'netmhcpan', 'netmhcii', 'netmhciipan'. Can be combined in a list separated by comma.
+      --tool_thresholds [str]               Specifies the affinity thresholds for each given tool. A peptides affinity above the threshold is considered as a binder. Can be combined in a list separated by comma.
       --peptides_split_maxchunks [int]      Used in combination with '--peptides' or '--proteins': maximum number of peptide chunks that will be created for parallelization. Default: 100
       --peptides_split_minchunksize [int]   Used in combination with '--peptides' or '--proteins': minimum number of peptides that should be written into one chunk. Default: 5000
 
@@ -583,6 +584,7 @@ process peptidePrediction {
                          --max_length ${params.max_peptide_length} \
                          --min_length ${params.min_peptide_length} \
                          --tools ${tools.join(",")} \
+                         --tool_thresholds ${params.tool_thresholds} \
                          --versions ${software_versions} \
                          --reference ${params.genome_version} \
                          ${ref_prot} \

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,6 +16,7 @@ params {
   max_peptide_length = (mhc_class == 1) ? 11 : 16
   min_peptide_length = (mhc_class == 1) ? 8 : 15
   tools = 'syfpeithi'
+  tool_thresholds = 50
   genome_version = 'GRCh37'
   wild_type = false
   fasta_output = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,7 +16,7 @@ params {
   max_peptide_length = (mhc_class == 1) ? 11 : 16
   min_peptide_length = (mhc_class == 1) ? 8 : 15
   tools = 'syfpeithi'
-  tool_thresholds = 50
+  tool_thresholds = ''
   genome_version = 'GRCh37'
   wild_type = false
   fasta_output = false


### PR DESCRIPTION
`create_binder_values` now takes an additional parameter `thresholds`, which is a dictionary containing the given tools as keys and the given thresholds as values. The dictionary is created in `assign_tool_thresholds`, which is called in the main method to obtain the new input parameter `--tool_thresholds`.

`make_predictions_from_peptides` and `make_predictions_from_variants` accept the mentioned dictionary to parse it to `create_binder_values`.

`--tool_thresholds` has been added as an additional parameter in `nextflow.config` and `main.nf `

Not sure if the Error warning for unequal tool and threshold numbers in `assign_tool_thresholds` is placed at the right location.