### PR TITLE
Adapt input parameter and paths in test configs to sample sheet

### DIFF
--- a/conf/test.config
+++ b/conf/test.config
@@ -19,11 +19,7 @@ params {
   max_time = 48.h
 
   // Input data
-  input = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/variants/variants.vcf'
-  alleles = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/alleles/alleles.txt'
-  // Ignore `--input` as otherwise the parameter validation will throw an error
+  input = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/sample_sheets/sample_sheet_variants.csv'
   schema_ignore_params = 'genomes,input_paths'
 
-  // Genome references
-  genome = 'R64-1-1'
 }

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -15,12 +15,6 @@ params {
     config_profile_description = 'Full test dataset to check pipeline function'
 
     // Input data for full size test
-    input = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/variants/variants.vcf'
-    alleles = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/alleles/alleles.txt'
-
-    // Ignore `--input` as otherwise the parameter validation will throw an error
+    input = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/sample_sheets/sample_sheet_variants.csv'
     schema_ignore_params = 'genomes,input_paths'
-
-    // Genome references
-    genome = 'R64-1-1'
 }

--- a/conf/test_mhcflurry.config
+++ b/conf/test_mhcflurry.config
@@ -14,9 +14,8 @@ params {
   max_cpus = 2
   max_memory = 6.GB
   max_time = 48.h
-  
+
   // Input data
-  input = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/variants/variants.vcf'
-  alleles = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/alleles/alleles.txt'
+  input = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/sample_sheets/sample_sheet_variants.csv'
   tools = 'mhcflurry'
 }

--- a/conf/test_mhcnuggets.config
+++ b/conf/test_mhcnuggets.config
@@ -14,9 +14,8 @@ params {
   max_cpus = 2
   max_memory = 6.GB
   max_time = 48.h
-  
+
   // Input data
-  input = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/variants/variants.vcf'
-  alleles = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/alleles/alleles.txt'
+  input = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/sample_sheets/sample_sheet_variants.csv'
   tools = 'mhcnuggets-class-1'
 }

--- a/conf/test_netmhc.config
+++ b/conf/test_netmhc.config
@@ -16,8 +16,7 @@ params {
   max_time = 48.h
 
   // Input data
-  peptides = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/peptides/peptides.tsv'
-  alleles = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/alleles/alleles.txt'
+  input = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/sample_sheets/sample_sheet_peptides.csv'
 
   tools = 'netmhc'
   netmhc_path = './non-free/netmhc.tar.gz'

--- a/conf/test_netmhcii.config
+++ b/conf/test_netmhcii.config
@@ -16,8 +16,7 @@ params {
   max_time = 48.h
 
   // Input data
-  peptides = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/peptides/peptides_MHC_II.txt'
-  alleles = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/alleles/alleles.DRB1_01_01.txt'
+  input = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/sample_sheets/sample_sheet_peptides_class2.csv'
 
   tools = 'netmhcii'
   netmhcii_path = './non-free/netmhcii.tar.Z'

--- a/conf/test_netmhciipan.config
+++ b/conf/test_netmhciipan.config
@@ -16,8 +16,7 @@ params {
   max_time = 48.h
 
   // Input data
-  peptides = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/peptides/peptides_MHC_II.txt'
-  alleles = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/alleles/alleles.DRB1_01_01.txt'
+  input = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/sample_sheets/sample_sheet_peptides_class2.csv'
 
   tools = 'netmhciipan'
   netmhciipan_path = './non-free/netmhciipan.tar.gz'

--- a/conf/test_netmhcpan.config
+++ b/conf/test_netmhcpan.config
@@ -16,8 +16,7 @@ params {
   max_time = 48.h
 
   // Input data
-  peptides = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/peptides/peptides.tsv'
-  alleles = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/alleles/alleles.txt'
+  input = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/sample_sheets/sample_sheet_peptides.csv'
 
   tools = 'netmhcpan'
   netmhcpan_path = './non-free/netmhcpan.tar.gz'

--- a/conf/test_peptides.config
+++ b/conf/test_peptides.config
@@ -13,6 +13,5 @@ params {
   max_time = 48.h
 
   // Input data
-  peptides = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/peptides/peptides.tsv'
-  alleles = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/alleles/alleles.txt'
+  input = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/sample_sheets/sample_sheet_peptides.csv'
 }

--- a/conf/test_peptides_h2.config
+++ b/conf/test_peptides_h2.config
@@ -13,8 +13,6 @@ params {
   max_time = 48.h
 
   // Input data
-  peptides = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/peptides/peptides.tsv'
-  alleles = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/alleles/alleles.H2.txt'
-
+  input = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/sample_sheets/sample_sheet_peptides_mouse.csv'
   tools = 'mhcnuggets-class-1'
 }

--- a/conf/test_proteins.config
+++ b/conf/test_proteins.config
@@ -13,6 +13,5 @@ params {
   max_time = 4.h
 
   // Input data
-  proteins = 'https://github.com/nf-core/test-datasets/raw/epitopeprediction/testdata/proteins/proteins.fasta'
-  alleles = 'https://github.com/nf-core/test-datasets/raw/epitopeprediction/testdata/alleles/alleles.txt'
+  input = 'https://github.com/nf-core/test-datasets/raw/epitopeprediction/testdata/sample_sheets/sample_sheet_proteins.csv'
 }

--- a/conf/test_variant_tsv.config
+++ b/conf/test_variant_tsv.config
@@ -13,6 +13,5 @@ params {
   max_time = 48.h
 
   // Input data
-  input = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/variants/variants.tsv'
-  alleles = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/alleles/alleles.txt'
+  input = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/sample_sheets/sample_sheet_variants_tab.csv'
 }


### PR DESCRIPTION
This changes the deprecated Input parameters to `input` and uses the available test-dataset sample sheets.

<!--
# nf-core/epitopeprediction pull request

Many thanks for contributing to nf-core/epitopeprediction!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
- [ ] If necessary, also make a PR on the [nf-core/epitopeprediction branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/epitopeprediction)
