### PR TITLE
Change sample sheet validation and parsing

### DIFF
--- a/subworkflows/local/input_check.nf
+++ b/subworkflows/local/input_check.nf
@@ -17,26 +17,18 @@ workflow INPUT_CHECK {
         .set { reads }
 
     emit:
-    reads // channel: [ val(meta), [ reads ] ]
+    reads // channel: [ val(meta), [ input filename ] ]
 }
 
 // Function to get list of [ meta, filenames ]
 def get_samplesheet_paths(LinkedHashMap row) {
 
-    // Collect the allele information from the file
-    def alleleString
-    if ( row.alleles.endsWith(".txt") || row.alleles.endsWith(".alleles") )  {
-        alleleString = file(row.alleles).readLines().join(';')
-    // or assign the information to a new variable
-    } else {
-        alleleString = row.alleles
-    }
-
+    def allele_string = generate_allele_string(row.alleles)
+    def type = determine_input_type(row.filename)
     def meta = [:]
     meta.sample         = row.sample
-    meta.alleles        = alleleString
-    meta.anno           = row.anno
-    meta.ext            = row.ext
+    meta.alleles        = allele_string
+    meta.inputtype      = type
 
     def array = []
     if (!file(row.filename).exists()) {
@@ -45,4 +37,40 @@ def get_samplesheet_paths(LinkedHashMap row) {
         array = [ meta, file(row.filename) ]
     }
     return array
+}
+
+def generate_allele_string(String alleles) {
+    // Collect the allele information from the file
+    def allele_string
+    if ( alleles.endsWith(".txt") || alleles.endsWith(".alleles") )  {
+        allele_string = file(alleles).readLines().join(';')
+    }
+    // or assign the information to a new variable
+    else {
+        allele_string = alleles
+    }
+    return allele_string
+}
+
+def determine_input_type(String filename) {
+    def filetype
+    def input_file = file(filename)
+    def extension = input_file.extension
+
+    if ( extension == "vcf" | extension == "vcf.gz" ) {
+        filetype = "variant"
+    }
+    else if ( extension == "tsv" | extension == "GSvar" ) {
+        // Check if it is a variant annotation file or a peptide file
+        input_file.withReader {
+            def first_header_col = it.readLine().split('\t')[0]
+            //first_header_col = [col.lower() for col in tsv.readlines()[0].split('\t')][0]
+            if (first_header_col == "id") { filetype = "peptide" }
+            else if (first_header_col == "#chr") {filetype = "variant"}
+        }
+    }
+    else {
+        filetype = "protein"
+    }
+    return filetype
 }

--- a/workflows/epitopeprediction.nf
+++ b/workflows/epitopeprediction.nf
@@ -136,9 +136,9 @@ workflow EPITOPEPREDICTION {
         meta, input_file ->
             variant : meta.inputtype == 'variant'
                 return [ meta, input_file ]
-            pep :  meta.inputtype == 'peptide'
+            peptide :  meta.inputtype == 'peptide'
                 return [ meta, input_file ]
-            prot :  meta.inputtype == 'protein'
+            protein :  meta.inputtype == 'protein'
                 return [ meta, input_file ]
             }
         .set { ch_samples_from_sheet }


### PR DESCRIPTION
This changes the validation and parsing of the sample sheet and moves parts of the functionality up to `input_check.nf` where we can access the file contents and therefore determine the input type that is given. No additional sample sheet columns are written anymore and  `input type` is forwarded through the `meta` map.

Some variable names in `epitopeprediction.nf` are changed and adapted. 

<!--
# nf-core/epitopeprediction pull request

Many thanks for contributing to nf-core/epitopeprediction!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
- [ ] If necessary, also make a PR on the [nf-core/epitopeprediction branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/epitopeprediction)
