### PR TITLE
Fix bugs

### DIFF
--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -28,7 +28,7 @@
             "filename": {
                 "type": "string",
                 "pattern": "^\\S+\\.(vcf|tsv|fasta|fa|txt)$",
-                "errorMessage": "Variants/proteins/peptides for sample must be provided and have one of the following extensions:  '.vcf', '.tsv', '.fasta', '.fa'"
+                "errorMessage": "Variants/proteins/peptides for sample must be provided and have one of the following extensions:  '.vcf', '.tsv', '.fasta', '.fa', '.txt'"
             }
         },
         "required": [

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -27,7 +27,7 @@
             },
             "filename": {
                 "type": "string",
-                "pattern": "^\\S+\\.(vcf|tsv|fasta|fa)$",
+                "pattern": "^\\S+\\.(vcf|tsv|fasta|fa|txt)$",
                 "errorMessage": "Variants/proteins/peptides for sample must be provided and have one of the following extensions:  '.vcf', '.tsv', '.fasta', '.fa'"
             }
         },

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -103,7 +103,7 @@ def check_samplesheet(file_in, file_out):
             sample, alleles, filename = lspl[: len(HEADER)]
 
             ## Check given file types
-            if not filename.lower().endswith((".vcf", ".vcf.gz", ".tsv", ".GSvar", ".fasta")):
+            if not filename.lower().endswith((".vcf", ".vcf.gz", ".tsv", ".GSvar", ".fasta", ".txt")):
                 print_error("Samplesheet contains unsupported file type!", "Line", line)
 
             sample_info = [sample, alleles, filename]

--- a/modules/local/check_requested_models.nf
+++ b/modules/local/check_requested_models.nf
@@ -19,7 +19,7 @@ process CHECK_REQUESTED_MODELS {
 
     input:
         tuple val(alleles), path(input_file)
-        val(software_versions)
+        path(software_versions)
 
     output:
         path '*.txt', emit: txt // model_report.txt


### PR DESCRIPTION
- Fixes bug with Filename ending with `.txt`
- Fixes bug in AWS batch with software versions in `Check_requested_models` process


```
Error executing process > 'NFCORE_EPITOPEPREDICTION:EPITOPEPREDICTION:CHECK_REQUESTED_MODELS (1)'

Caused by:
  Essential container in task exited

Command executed:

  check_requested_models.py --tools syfpeithi  --max_length 11 --min_length 8              --alleles 'A*01:01'             --mhcclass 1             --versions /nf-core-awsmegatests/work/epitopeprediction/58/9f7a8c8492118502ee4339b649f99c/versions.csv > model_warnings.log
  
  cat <<-END_VERSIONS > versions.yml
  CHECK_REQUESTED_MODELS:
      mhcflurry: $(echo $(mhcflurry-predict --version 2>&1 | sed 's/^mhcflurry //; s/ .*$//') )
      mhcnuggets: $(echo $(python -c "import pkg_resources; print(pkg_resources.get_distribution('mhcnuggets').version)"))
      fred2: $(echo $(python -c "import pkg_resources; print(pkg_resources.get_distribution('Fred2').version)"))
  END_VERSIONS

Command exit status:
  1

Command output:
  (empty)

Command error:
  Using TensorFlow backend.
  Traceback (most recent call last):
    File "//nextflow-bin/check_requested_models.py", line 135, in <module>
      __main__()
    File "//nextflow-bin/check_requested_models.py", line 59, in __main__
      with open(args.versions, 'r') as versions_file:
  IOError: [Errno 2] No such file or directory: '/nf-core-awsmegatests/work/epitopeprediction/58/9f7a8c8492118502ee4339b649f99c/versions.csv'

Work dir:
  s3://nf-core-awsmegatests/work/epitopeprediction/9d/8d0f5ff129e49ff808d8e6e21d94fe

Tip: when you have fixed the problem you can continue the execution adding the option `-resume` to the run command line
```