### PR TITLE
Remove netmhcii specs and deactivate corresponding tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,12 +125,6 @@ jobs:
       - name: Run pipeline with NetMHC
         run: |
           nextflow run ${GITHUB_WORKSPACE} -profile test_netmhc,docker
-      - name: Run pipeline with NetMHCII
-        run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test_netmhcii,docker
       - name: Run pipeline with NetMHCpan
         run: |
           nextflow run ${GITHUB_WORKSPACE} -profile test_netmhcpan,docker
-      - name: Run pipeline with NetMHCIIpan
-        run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test_netmhciipan,docker

--- a/nextflow.config
+++ b/nextflow.config
@@ -140,9 +140,7 @@ profiles {
     test_mhcnuggets { includeConfig 'conf/test_mhcnuggets.config' }
     test_mhcflurry { includeConfig 'conf/test_mhcflurry.config' }
     test_netmhc { includeConfig 'conf/test_netmhc.config' }
-    test_netmhcii { includeConfig 'conf/test_netmhcii.config' }
     test_netmhcpan { includeConfig 'conf/test_netmhcpan.config' }
-    test_netmhciipan { includeConfig 'conf/test_netmhciipan.config' }
     test_full { includeConfig 'conf/test_full.config' }
 }
 

--- a/workflows/epitopeprediction.nf
+++ b/workflows/epitopeprediction.nf
@@ -128,20 +128,6 @@ workflow EPITOPEPREDICTION {
             data_url     : "https://services.healthtech.dtu.dk/services/NetMHCpan-4.0/data.Linux.tar.gz",
             data_md5     : "26cbbd99a38f6692249442aeca48608f",
             binary_name  : "netMHCpan"
-        ],
-        netmhcii: [
-            version      : "2.2",
-            software_md5 : "918b7108a37599887b0725623d0974e6",
-            data_url     : "https://services.healthtech.dtu.dk/services/NetMHCII-2.2/data.tar.gz",
-            data_md5     : "11579b61d3bfe13311f7b42fc93b4dd8",
-            binary_name  : "netMHCII"
-        ],
-        netmhciipan: [
-            version      : "3.1",
-            software_md5 : "0962ce799f7a4c9631f8566a55237073",
-            data_url     : "https://services.healthtech.dtu.dk/services/NetMHCIIpan-3.1/data.tar.gz",
-            data_md5     : "f833df245378e60ca6e55748344a36f6",
-            binary_name  : "netMHCIIpan"
         ]
     ]
 
@@ -224,7 +210,7 @@ workflow EPITOPEPREDICTION {
     }
 
     // Retrieve meta data for external tools
-    ["netmhc", "netmhcpan", "netmhcii", "netmhciipan"].each {
+    ["netmhc", "netmhcpan"].each {
         // Check if the _path parameter was set for this tool
         if (params["${it}_path"] as Boolean && ! tools.contains(it))
         {


### PR DESCRIPTION
This removes the support for the tools netmhcII and netmhcIIpan since the versions that supported by FRED2 are not provided anymore by the developer of the netmhc tools. We will probably add more recent versions of these tools again later.

I kept the parameters for the tool executables and the test profiles, but we can discuss if it would be better to remove these as well for now.

<!--
# nf-core/epitopeprediction pull request

Many thanks for contributing to nf-core/epitopeprediction!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
- [ ] If necessary, also make a PR on the [nf-core/epitopeprediction branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/epitopeprediction)
