### PR TITLE
Change result folder structure

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -51,6 +51,9 @@ process {
     }
 
     withName: FRED2_GENERATEPEPTIDES {
+        publishDir = [
+            path: { "${params.outdir}/generated_peptides/${meta.sample}" },
+        ]
         ext.args = "--max_length ${params.max_peptide_length} --min_length ${params.min_peptide_length} "
     }
 
@@ -64,7 +67,7 @@ process {
 
     withName: PEPTIDE_PREDICTION_PROTEIN {
         publishDir = [
-            path: { "${params.outdir}/predictions" },
+            path: { "${params.outdir}/split_predictions/${meta.sample}" },
         ]
         // Argument list needs to end with --peptides
         ext.args = "--tools ${params.tools} --mhcclass ${params.mhc_class} --max_length ${params.max_peptide_length} --min_length ${params.min_peptide_length} --reference ${params.genome_version} --peptides"
@@ -72,7 +75,7 @@ process {
 
     withName: PEPTIDE_PREDICTION_PEP {
         publishDir = [
-            path: { "${params.outdir}/predictions" },
+            path: { "${params.outdir}/split_predictions/${meta.sample}" },
         ]
         // Argument list needs to end with --peptides
         ext.args = "--tools ${params.tools} --mhcclass ${params.mhc_class} --max_length ${params.max_peptide_length} --min_length ${params.min_peptide_length} --reference ${params.genome_version} --peptides"
@@ -80,7 +83,7 @@ process {
 
     withName: PEPTIDE_PREDICTION_VAR {
         publishDir = [
-            path: { "${params.outdir}/predictions" },
+            path: { "${params.outdir}/split_predictions/${meta.sample}" },
         ]
         // Argument list needs to end with --somatic_mutation
         ext.args = "--tools ${params.tools} --mhcclass ${params.mhc_class} --max_length ${params.max_peptide_length} --min_length ${params.min_peptide_length} --reference ${params.genome_version} --somatic_mutation"
@@ -96,25 +99,25 @@ process {
 
     withName: CAT_TSV {
         publishDir = [
-            path: { "${params.outdir}/merged_predictions" },
+            path: { "${params.outdir}/predictions/${meta.sample}" },
         ]
     }
 
     withName: CAT_FASTA {
         publishDir = [
-            path: { "${params.outdir}/merged_predictions" },
+            path: { "${params.outdir}/predictions/${meta.sample}" },
         ]
     }
 
     withName: CSVTK_CONCAT {
         publishDir = [
-            path: { "${params.outdir}/merged_predictions" },
+            path: { "${params.outdir}/predictions/${meta.sample}" },
         ]
     }
 
     withName: CSVTK_SPLIT {
         publishDir = [
-            path: { "${params.outdir}/splitted" },
+            path: { "${params.outdir}/split_input/${meta.sample}" },
         ]
     }
 
@@ -126,7 +129,7 @@ process {
 
     withName: MERGE_JSON {
         publishDir = [
-            path: { "${params.outdir}/merged_predictions" },
+            path: { "${params.outdir}/predictions/${meta.sample}" },
         ]
     }
 
@@ -138,13 +141,13 @@ process {
 
     withName: SNPSIFT_SPLIT {
         publishDir = [
-            path: { "${params.outdir}/splitted" },
+            path: { "${params.outdir}/split_input/${meta.sample}" },
         ]
     }
 
     withName: SPLIT_PEPTIDES {
         publishDir = [
-            path: { "${params.outdir}/splitted" },
+            path: { "${params.outdir}/split_input/${meta.sample}" },
         ]
     }
 }


### PR DESCRIPTION
This changes the result folder structure to the following

```
.
+-- predictions
|   +-- sample1
|         +-- predictions.tsv
|   +-- sample2
...
+-- split_predictions
|   +-- sample1
...
+-- split_input
|   +-- sample1
...
```

So I guess it should be more obvious where to find the final results and the results are grouped by sample. In case of protein input there will be a folder `generated_peptides` which has been created as `fred2` before. 

What do you think @ggabernet @marissaDubbelaar @jonasscheid ? If you agree, I will still change the documentation accordingly.

Fixes #131 

<!--
# nf-core/epitopeprediction pull request

Many thanks for contributing to nf-core/epitopeprediction!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
