### PR TITLE
Fix unique variant annotation field handling #136

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-- [#136](https://github.com/nf-core/epitopeprediction/pull/135) - Allow variants with unique annotation fields
+- [#135](https://github.com/nf-core/epitopeprediction/pull/135) - Fix unique variant annotation field handling
 ## v2.0.0 - Heuberg - 2021-12-20
 
 ### `Added`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-- [#135](https://github.com/nf-core/epitopeprediction/pull/135) - Fix unique variant annotation field handling
+- [#135](https://github.com/nf-core/epitopeprediction/pull/135) - Fix unique variant annotation field handling [#136](https://github.com/nf-core/epitopeprediction/issues/136)
 ## v2.0.0 - Heuberg - 2021-12-20
 
 ### `Added`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#136](https://github.com/nf-core/epitopeprediction/pull/135) - Allow variants with unique annotation fields
 ## v2.0.0 - Heuberg - 2021-12-20
 
 ### `Added`

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -531,7 +531,7 @@ def create_metadata_column_value(pep, c):
     transcript_ids = [x.transcript_id for x in set(pep[0].get_all_transcripts())]
     variants = []
     for t in transcript_ids:
-        variants.extend([v for v in pep[0].get_variants_by_protein(t)]) 
+        variants.extend([v for v in pep[0].get_variants_by_protein(t)])
     meta = set([str(y.get_metadata(c)[0]) for y in set(variants) if len(y.get_metadata(c)) != 0])
     if len(meta) is 0:
         return np.nan

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -531,8 +531,8 @@ def create_metadata_column_value(pep, c):
     transcript_ids = [x.transcript_id for x in set(pep[0].get_all_transcripts())]
     variants = []
     for t in transcript_ids:
-        variants.extend([v for v in pep[0].get_variants_by_protein(t)])
-    meta = set([str(y.get_metadata(c)[0]) for y in set(variants)])
+        variants.extend([v for v in pep[0].get_variants_by_protein(t)]) 
+    meta = set([str(y.get_metadata(c)[0]) for y in set(variants) if len(y.get_metadata(c)) != 0])
     if len(meta) is 0:
         return np.nan
     else:


### PR DESCRIPTION
Minor change:
Some variants in SnpEff (v.4.3t) contain a `LOF` flag, which altered the dynamic structure of variant annotations. Since most variants do not have this flag, it caused an error. In general, the pipeline crashes, when a variant has metadata, which other variants don't have.

This PR closes #136
<!--
# nf-core/epitopeprediction pull request

Many thanks for contributing to nf-core/epitopeprediction!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
