### PR TITLE
Check FORMAT entries in VCF parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 - [#135](https://github.com/nf-core/epitopeprediction/pull/135) - Fix unique variant annotation field handling [#136](https://github.com/nf-core/epitopeprediction/issues/136)
+- [#144](https://github.com/nf-core/epitopeprediction/pull/144) - Fix VCF file parsing [#142](https://github.com/nf-core/epitopeprediction/issues/142)
 
 ## v2.0.0 - Heuberg - 2021-12-20
 

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -322,6 +322,9 @@ def read_vcf(filename, pass_only=True):
 
                     for sample in record.samples:
                         for format_key in format_list:
+                            if not getattr(sample.data, format_key, None):
+                                logger.warning("FORMAT entry {entry} not defined for {genotype}. Skipping.".format(entry=format_key, genotype=sample.sample))
+                                continue
                             format_header = '{}.{}'.format(sample.sample, format_key)
                             final_metadata_list.append(format_header)
                             if isinstance(sample[format_key], list):


### PR DESCRIPTION
This adds a check during VCF file parsing whether the specified format entry is given for the respective genotypes.
Fixes #142.

<!--
# nf-core/epitopeprediction pull request

Many thanks for contributing to nf-core/epitopeprediction!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
