### PR TITLE
Support gzipped variant input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
+- [#145](https://github.com/nf-core/epitopeprediction/pull/145) - Add functionality for handling gzipped VCF files for [#143](https://github.com/nf-core/epitopeprediction/issues/143)
+
 ### `Changed`
 
 ### `Fixed`

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -127,6 +127,12 @@ process {
         ]
     }
 
+    withName: GUNZIP_VCF {
+        publishDir  = [
+            enabled: false
+        ]
+    }
+
     withName: MERGE_JSON {
         publishDir = [
             path: { "${params.outdir}/predictions/${meta.sample}" },

--- a/modules.json
+++ b/modules.json
@@ -6,6 +6,9 @@
             "custom/dumpsoftwareversions": {
                 "git_sha": "20d8250d9f39ddb05dfb437603aaf99b5c0b2b41"
             },
+            "gunzip": {
+                "git_sha": "e745e167c1020928ef20ea1397b6b4d230681b4d"
+            },
             "multiqc": {
                 "git_sha": "20d8250d9f39ddb05dfb437603aaf99b5c0b2b41"
             }

--- a/modules/local/snpsift_split.nf
+++ b/modules/local/snpsift_split.nf
@@ -18,8 +18,8 @@ process SNPSIFT_SPLIT {
     SnpSift split ${input_file}
 
     cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            snpsift: \$(echo \$(snpsift -version 2>&1 | sed -n 3p | cut -d\$' ' -f3))
+    "${task.process}":
+        snpsift: \$( echo \$(SnpSift split -h 2>&1) | sed 's/^.*version //' | sed 's/(.*//' | sed 's/t//g' )
     END_VERSIONS
     """
 }

--- a/modules/nf-core/modules/gunzip/main.nf
+++ b/modules/nf-core/modules/gunzip/main.nf
@@ -1,0 +1,34 @@
+process GUNZIP {
+    tag "$archive"
+    label 'process_low'
+
+    conda (params.enable_conda ? "conda-forge::sed=4.7" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img' :
+        'biocontainers/biocontainers:v1.2.0_cv1' }"
+
+    input:
+    tuple val(meta), path(archive)
+
+    output:
+    tuple val(meta), path("$gunzip"), emit: gunzip
+    path "versions.yml"             , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    gunzip = archive.toString() - '.gz'
+    """
+    gunzip \\
+        -f \\
+        $args \\
+        $archive
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        gunzip: \$(echo \$(gunzip --version 2>&1) | sed 's/^.*(gzip) //; s/ Copyright.*\$//')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/modules/gunzip/meta.yml
+++ b/modules/nf-core/modules/gunzip/meta.yml
@@ -1,0 +1,34 @@
+name: gunzip
+description: Compresses and decompresses files.
+keywords:
+  - gunzip
+  - compression
+tools:
+  - gunzip:
+    description: |
+      gzip is a file format and a software application used for file compression and decompression.
+    documentation: https://www.gnu.org/software/gzip/manual/gzip.html
+    licence: ["GPL-3.0-or-later"]
+input:
+  - meta:
+    type: map
+    description: |
+      Optional groovy Map containing meta information
+      e.g. [ id:'test', single_end:false ]
+  - archive:
+    type: file
+    description: File to be compressed/uncompressed
+    pattern: "*.*"
+output:
+  - gunzip:
+    type: file
+    description: Compressed/uncompressed file
+    pattern: "*.*"
+  - versions:
+    type: file
+    description: File containing software versions
+    pattern: "versions.yml"
+authors:
+  - "@joseespinosa"
+  - "@drpatelh"
+  - "@jfy133"

--- a/subworkflows/local/input_check.nf
+++ b/subworkflows/local/input_check.nf
@@ -57,7 +57,10 @@ def determine_input_type(String filename) {
     def input_file = file(filename)
     def extension = input_file.extension
 
-    if ( extension == "vcf" | filename.endsWith("vcf.gz") ) {
+    if (filename.endsWith("vcf.gz") ) {
+        filetype = "variant_compressed"
+    }
+    else if (extension == "vcf") {
         filetype = "variant"
     }
     else if ( extension == "tsv" | extension == "GSvar" ) {

--- a/subworkflows/local/input_check.nf
+++ b/subworkflows/local/input_check.nf
@@ -57,7 +57,7 @@ def determine_input_type(String filename) {
     def input_file = file(filename)
     def extension = input_file.extension
 
-    if ( extension == "vcf" | extension == "vcf.gz" ) {
+    if ( extension == "vcf" | filename.endsWith("vcf.gz") ) {
         filetype = "variant"
     }
     else if ( extension == "tsv" | extension == "GSvar" ) {

--- a/workflows/epitopeprediction.nf
+++ b/workflows/epitopeprediction.nf
@@ -105,7 +105,7 @@ workflow EPITOPEPREDICTION {
     INPUT_CHECK.out.reads
                 .branch {
                     meta_data, input_file ->
-                        variant_compressed : meta_data.inputtype == 'variant' & input_file.toString().endsWith('.gz')
+                        variant_compressed : meta_data.inputtype == 'variant_compressed'
                             return [ meta_data, input_file ]
                         variant_uncompressed :  meta_data.inputtype == 'variant'
                             return [ meta_data, input_file ]
@@ -132,7 +132,7 @@ workflow EPITOPEPREDICTION {
         .mix(ch_variants_uncompressed)
         .branch {
                 meta_data, input_file ->
-                variant :  meta_data.inputtype == 'variant'
+                variant :  meta_data.inputtype == 'variant' | meta_data.inputtype == 'variant_compressed'
                 peptide :  meta_data.inputtype == 'peptide'
                 protein :  meta_data.inputtype == 'protein'
             }


### PR DESCRIPTION
This adds support for gzipped VCF file input. Fixes #143. 

- add nf-core/gunzip module
- handle gzipped VCF files in workflow
- fix snpsift version print in the module

<!--
# nf-core/epitopeprediction pull request

Many thanks for contributing to nf-core/epitopeprediction!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
