### PR TITLE
Add functionality for splitting input VCF files by variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added`
 
 - [#145](https://github.com/nf-core/epitopeprediction/pull/145) - Add functionality for handling gzipped VCF files for [#143](https://github.com/nf-core/epitopeprediction/issues/143)
+- [#155](https://github.com/nf-core/epitopeprediction/pull/155) - Add functionality for splitting input VCF files by the number of variants [#140](https://github.com/nf-core/epitopeprediction/issues/140)
 
 ### `Changed`
 

--- a/bin/split_vcf_by_variants.py
+++ b/bin/split_vcf_by_variants.py
@@ -12,11 +12,11 @@ def determine_split_size(input_file, size):
         input_lines = variants.readlines()
         num_variants = sum(1 for i in input_lines if not i.startswith('#'))
     if not size:
-        return int(num_variants / 10)
+        return max( int(num_variants / 10), 1)
     elif num_variants < size:
         logging.warning(
             'Provided split size larger than number of variants. Using default value.')
-        return int(num_variants / 10)
+        return max( int(num_variants / 10), 1)
     else:
         return size
 

--- a/bin/split_vcf_by_variants.py
+++ b/bin/split_vcf_by_variants.py
@@ -7,8 +7,8 @@ import os
 from typing import Optional
 
 
-def determine_split_size(inputFile, size):
-    with open(inputFile, "r") as variants:
+def determine_split_size(input_file, size):
+    with open(input_file, "r") as variants:
         input_lines = variants.readlines()
         num_variants = sum(1 for i in input_lines if not i.startswith('#'))
     if not size:
@@ -36,10 +36,10 @@ def main():
 
     split_size = determine_split_size(args.input, args.size)
     file_name = args.input.split('.')[0]
-    varGroupCount = 0
-    fileCount = 1
+    var_group_count = 0
+    file_count = 1
     metadata = ''
-    varGroup = ''
+    var_group = ''
 
     with open(args.input, 'r') as input_file:
         vcf_file = csv.reader(input_file, delimiter="\t")
@@ -49,26 +49,27 @@ def main():
                 metadata += ('\t').join(line)
                 metadata += '\n'
             else:
-                varGroup += ('\t').join(line)
-                varGroup += '\n'
+                var_group += ('\t').join(line)
+                var_group += '\n'
                 # Get chromosome and positional information of the transcript
                 transcript = (line[0], int(line[1]))
                 # Check if the current number of saved variants is lower the number of desired variants per split
-                if varGroupCount < split_size:
-                    varGroupCount += 1
+                if var_group_count < split_size:
+                    var_group_count += 1
                 # Check if previous variant might be in the same transcript by checking chr and pos information
-                elif transcript[0] == previousTranscript[0] and transcript[1] < previousTranscript[1] + args.distance:
-                    varGroupCount += 1
+                elif transcript[0] == previous_transcript[0] and transcript[1] < previous_transcript[1] + args.distance:
+                    var_group_count += 1
                 # write split to new VCF file
                 else:
-                    with open(os.path.join(args.output, f'{file_name}_chunk_{fileCount}.vcf'), 'w') as outputFile:
-                        outputFile.write(metadata + varGroup)
-                        varGroup = ""
-                        varGroupCount = 0
-                        fileCount += 1
-                previousTranscript = transcript
-        with open(os.path.join(args.output, f'{file_name}_chunk_{fileCount}.vcf'), 'w') as outputFile:
-            outputFile.write(metadata + varGroup)
+                    with open(os.path.join(args.output, f'{file_name}_chunk_{file_count}.vcf'), 'w') as output_file:
+                        output_file.write(metadata + var_group)
+                        var_group = ""
+                        var_group_count = 0
+                        file_count += 1
+                previous_transcript = transcript
+        if var_group:
+            with open(os.path.join(args.output, f'{file_name}_chunk_{file_count}.vcf'), 'w') as output_file:
+                output_file.write(metadata + var_group)
 
 
 if __name__ == "__main__":

--- a/bin/split_vcf_by_variants.py
+++ b/bin/split_vcf_by_variants.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+
+import argparse
+import logging
+import csv
+import os
+from typing import Optional
+
+
+def determine_split_size(inputFile, size):
+    with open(inputFile, "r") as variants:
+        input_lines = variants.readlines()
+        num_variants = sum(1 for i in input_lines if not i.startswith('#'))
+    if not size:
+        return int(num_variants / 10)
+    elif num_variants < size:
+        logging.warning(
+            'Provided split size larger than number of variants. Using default value.')
+        return int(num_variants / 10)
+    else:
+        return size
+
+
+def main():
+    parser = argparse.ArgumentParser("Split vcf file into multiple files.")
+    parser.add_argument('-i', '--input', metavar='FILE',
+                        type=str, help='Input VCF file containing variants.', )
+    parser.add_argument('-s', '--size', metavar='N', type=int, required=False,
+                        help='Number of variants that should be written into one file. Default: number of variants / 10')
+    parser.add_argument('-d', '--distance', metavar='N', type=int, default=110000,
+                        help='Number of nucleotides between previous and current variant. Default: 110000')
+    parser.add_argument('-o', '--output', metavar='N',
+                        help='Output directory')
+
+    args = parser.parse_args()
+
+    split_size = determine_split_size(args.input, args.size)
+    file_name = args.input.split('.')[0]
+    varGroupCount = 0
+    fileCount = 1
+    metadata = ''
+    varGroup = ''
+
+    with open(args.input, 'r') as input_file:
+        vcf_file = csv.reader(input_file, delimiter="\t")
+
+        for line in vcf_file:
+            if line[0].startswith('#'):
+                metadata += ('\t').join(line)
+                metadata += '\n'
+            else:
+                varGroup += ('\t').join(line)
+                varGroup += '\n'
+                # Get chromosome and positional information of the transcript
+                transcript = (line[0], int(line[1]))
+                # Check if the current number of saved variants is lower the number of desired variants per split
+                if varGroupCount < split_size:
+                    varGroupCount += 1
+                # Check if previous variant might be in the same transcript by checking chr and pos information
+                elif transcript[0] == previousTranscript[0] and transcript[1] < previousTranscript[1] + args.distance:
+                    varGroupCount += 1
+                # write split to new VCF file
+                else:
+                    with open(os.path.join(args.output, f'{file_name}_chunk_{fileCount}.vcf'), 'w') as outputFile:
+                        outputFile.write(metadata + varGroup)
+                        varGroup = ""
+                        varGroupCount = 0
+                        fileCount += 1
+                previousTranscript = transcript
+        with open(os.path.join(args.output, f'{file_name}_chunk_{fileCount}.vcf'), 'w') as outputFile:
+            outputFile.write(metadata + varGroup)
+
+
+if __name__ == "__main__":
+    main()

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -147,6 +147,12 @@ process {
         ]
     }
 
+    withName: VARIANT_SPLIT {
+        publishDir = [
+            path: { "${params.outdir}/split_input/${meta.sample}" }
+        ]
+    }
+
     withName: SNPSIFT_SPLIT {
         publishDir = [
             path: { "${params.outdir}/split_input/${meta.sample}" }

--- a/modules/local/variant_split.nf
+++ b/modules/local/variant_split.nf
@@ -8,8 +8,6 @@ process VARIANT_SPLIT {
 
     input:
     tuple val(meta), path(input_file)
-    val size
-    val distance
 
     output:
     tuple val(meta), path("*.vcf"), emit: splitted
@@ -17,8 +15,8 @@ process VARIANT_SPLIT {
 
     script:
 
-    def size_parameter = size ? "--size ${size}" : ''
-    def distance_parameter = distance ? "--distance ${distance}" : ''
+    def size_parameter = params.split_by_variants_size ? "--size ${params.split_by_variants_size}" : ''
+    def distance_parameter = params.split_by_variants_distance ? "--distance ${params.split_by_variants_distance}" : ''
 
     """
     split_vcf_by_variants.py --input ${input_file} ${size_parameter} ${distance_parameter} --output .

--- a/modules/local/variant_split.nf
+++ b/modules/local/variant_split.nf
@@ -1,0 +1,32 @@
+process VARIANT_SPLIT {
+    label 'process_low'
+
+    conda (params.enable_conda ? "conda-forge::python=3.8.3" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/python:3.8.3' :
+        'quay.io/biocontainers/python:3.8.3' }"
+
+    input:
+    tuple val(meta), path(input_file)
+    val size
+    val distance
+
+    output:
+    tuple val(meta), path("*.vcf"), emit: splitted
+    path "versions.yml", emit: versions
+
+    script:
+
+    def size_parameter = size ? "--size ${size}" : ''
+    def distance_parameter = distance ? "--distance ${distance}" : ''
+
+    """
+    split_vcf_by_variants.py --input ${input_file} ${size_parameter} ${distance_parameter} --output .
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        python: \$(python --version 2>&1 | sed 's/Python //g')
+    END_VERSIONS
+    """
+
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,6 +12,9 @@ params {
     input = null
     peptides_split_maxchunks = 100
     peptides_split_minchunksize = 5000
+    split_by_variants = false
+    split_by_variants_size = null
+    split_by_variants_distance = 110000
 
     // References
     genome_version = 'GRCh37'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -10,10 +10,7 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": [
-                "input",
-                "outdir"
-            ],
+            "required": ["input", "outdir"],
             "properties": {
                 "input": {
                     "type": "string",
@@ -55,10 +52,7 @@
                     "type": "string",
                     "default": "GRCh37",
                     "help_text": "This defines against which human reference genome the pipeline performs the analysis including the incorporation of genetic variants e.g..",
-                    "enum": [
-                        "GRCh37",
-                        "GRCh38"
-                    ],
+                    "enum": ["GRCh37", "GRCh38"],
                     "description": "Specifies  the human reference genome version."
                 },
                 "proteome": {
@@ -99,10 +93,7 @@
                     "default": 1,
                     "description": "MHC class for prediction.",
                     "help_text": "Specifies whether the predictions should be done for MHC class I or class II.",
-                    "enum": [
-                        1,
-                        2
-                    ]
+                    "enum": [1, 2]
                 },
                 "max_peptide_length": {
                     "type": "integer",
@@ -311,14 +302,7 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": [
-                        "symlink",
-                        "rellink",
-                        "link",
-                        "copy",
-                        "copyNoFollow",
-                        "move"
-                    ],
+                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
                     "hidden": true
                 },
                 "email_on_fail": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -10,7 +10,10 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": ["input", "outdir"],
+            "required": [
+                "input",
+                "outdir"
+            ],
             "properties": {
                 "input": {
                     "type": "string",
@@ -52,7 +55,10 @@
                     "type": "string",
                     "default": "GRCh37",
                     "help_text": "This defines against which human reference genome the pipeline performs the analysis including the incorporation of genetic variants e.g..",
-                    "enum": ["GRCh37", "GRCh38"],
+                    "enum": [
+                        "GRCh37",
+                        "GRCh38"
+                    ],
                     "description": "Specifies  the human reference genome version."
                 },
                 "proteome": {
@@ -93,7 +99,10 @@
                     "default": 1,
                     "description": "MHC class for prediction.",
                     "help_text": "Specifies whether the predictions should be done for MHC class I or class II.",
-                    "enum": [1, 2]
+                    "enum": [
+                        1,
+                        2
+                    ]
                 },
                 "max_peptide_length": {
                     "type": "integer",
@@ -141,6 +150,22 @@
             "description": "Options for optimising the pipeline run execution.",
             "fa_icon": "fas fa-history",
             "properties": {
+                "split_by_variants": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Split VCF file into multiple files by number of variants."
+                },
+                "split_by_variants_size": {
+                    "type": "string",
+                    "default": "null",
+                    "description": "Number of variants that should be written into one file. Default: number of variants divided by ten"
+                },
+                "split_by_variants_distance": {
+                    "type": "integer",
+                    "default": 110000,
+                    "description": "Number of nucleotides between previous and current variant across split.",
+                    "help_text": "This can be used to avoid that variants end up in separate splits that fall onto the same transcript and therefore potentially contribute to the same mutated protein. "
+                },
                 "peptides_split_maxchunks": {
                     "type": "integer",
                     "default": 100,
@@ -286,7 +311,14 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
+                    "enum": [
+                        "symlink",
+                        "rellink",
+                        "link",
+                        "copy",
+                        "copyNoFollow",
+                        "move"
+                    ],
                     "hidden": true
                 },
                 "email_on_fail": {

--- a/workflows/epitopeprediction.nf
+++ b/workflows/epitopeprediction.nf
@@ -286,9 +286,7 @@ workflow EPITOPEPREDICTION {
     // decide between the split_by_variants and snpsift_split (by chromosome) function (only vcf and vcf.gz variant files)
     if (params.split_by_variants) {
         VARIANT_SPLIT(
-            ch_variants.vcf,
-            params.split_by_variants_size ?: [],
-            params.split_by_variants_distance ?: []
+            ch_variants.vcf
         )
         .set { ch_split_variants }
         ch_versions = ch_versions.mix( VARIANT_SPLIT.out.versions.ifEmpty(null) )


### PR DESCRIPTION
This
- adds the functionality to split input VCF files by variants in order to e.g. create smaller input chunks than with splitting by chromosome. Splitting can be configured with two new parameters `split_by_variants_size` and `split_by_variants_distance`.
- adresses #140 

<!--
# nf-core/epitopeprediction pull request

Many thanks for contributing to nf-core/epitopeprediction!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
