### PR TITLE
add config for external prediction tools

### DIFF
--- a/assets/external_tools_meta.json
+++ b/assets/external_tools_meta.json
@@ -1,0 +1,56 @@
+{
+    "netmhc": {
+        "4.0": {
+            "version": 4.0,
+            "software_md5": "132dc322da1e2043521138637dd31ebf",
+            "data_url": "https://services.healthtech.dtu.dk/services/NetMHC-4.0/data.tar.gz",
+            "data_md5": "63c646fa0921d617576531396954d633",
+            "binary_name": "netMHC"
+        }
+    },
+    "netmhc_darwin": {
+        "4.0": {
+            "version": 4.0,
+            "software_md5": "43519de644c67ee4c8ee04c673861568",
+            "data_url": "https://services.healthtech.dtu.dk/services/NetMHC-4.0/data.tar.gz",
+            "data_md5": "63c646fa0921d617576531396954d633",
+            "binary_name": "netMHC"
+        }
+    },
+    "netmhcpan": {
+        "4.0": {
+            "version": 4.0,
+            "software_md5": "94aa60f3dfd9752881c64878500e58f3",
+            "data_url": "https://services.healthtech.dtu.dk/services/NetMHCpan-4.0/data.Linux.tar.gz",
+            "data_md5": "26cbbd99a38f6692249442aeca48608f",
+            "binary_name": "netMHCpan"
+        }
+    },
+    "netmhcpan_darwin": {
+        "4.0": {
+            "version": 4.0,
+            "software_md5": "042d16b89adcf5656ca4deae06b55cc6",
+            "data_url": "https://services.healthtech.dtu.dk/services/NetMHCpan-4.0/data.Darwin.tar.gz",
+            "data_md5": "b4eef3c82852d677a98e0f7d753a36e2",
+            "binary_name": "netMHCpan"
+        }
+    },
+    "netmhcii": {
+        "2.2": {
+            "version": 2.2,
+            "software_md5": "918b7108a37599887b0725623d0974e6",
+            "data_url": "https://services.healthtech.dtu.dk/services/NetMHCII-2.2/data.tar.gz",
+            "data_md5": "11579b61d3bfe13311f7b42fc93b4dd8",
+            "binary_name": "netMHCII"
+        }
+    },
+    "netmhciipan": {
+        "3.1": {
+            "version": 3.1,
+            "software_md5": "0962ce799f7a4c9631f8566a55237073",
+            "data_url": "https://services.healthtech.dtu.dk/services/NetMHCIIpan-3.1/data.tar.gz",
+            "data_md5": "f833df245378e60ca6e55748344a36f6",
+            "binary_name": "netMHCIIpan"
+        }
+    }
+}

--- a/bin/check_requested_models.py
+++ b/bin/check_requested_models.py
@@ -55,7 +55,7 @@ def __main__():
     parser.add_argument('-t', '--tools', help='Tools requested for peptide predictions', required=True, type=str)
     parser.add_argument('-v', '--versions', help='<Required> File with used software versions.', required=True)
     args = parser.parse_args()
-    selected_methods = [item for item in args.tools.split(',')]
+    selected_methods = [item.split('-')[0] for item in args.tools.split(',')]
     with open(args.versions, 'r') as versions_file:
         tool_version = [ (row[0].split()[0], str(row[1])) for row in csv.reader(versions_file, delimiter = ":") ]
         # NOTE this needs to be updated, if a newer version will be available via epytope and should be used in the future

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -1019,7 +1019,7 @@ def __main__():
         else:
             up_db.read_seqs(args.reference_proteome)
 
-    selected_methods = [item for item in args.tools.split(',')]
+    selected_methods = [item.split('-')[0] for item in args.tools.split(',')]
     with open(args.versions, 'r') as versions_file:
         tool_version = [ (row[0].split()[0], str(row[1])) for row in csv.reader(versions_file, delimiter = ":") ]
         # NOTE this needs to be updated, if a newer version will be available via epytope and should be used in the future

--- a/nextflow.config
+++ b/nextflow.config
@@ -27,6 +27,9 @@ params {
     // Options: Filtering
     filter_self = false
     show_supported_models = false
+
+    // External tools
+    external_tools_meta = "${projectDir}/assets/external_tools_meta.json"
     netmhc_system = 'linux'
     netmhcpan_path = null
     netmhc_path = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -110,7 +110,7 @@
                 "tools": {
                     "type": "string",
                     "default": "syfpeithi",
-                    "help_text": "Specifies the tool(s) to use. Available are: `syfpeithi`, `mhcflurry`, `mhcnuggets-class-1`, `mhcnuggets-class-2`. Can be combined in a list separated by comma.",
+                    "help_text": "Specifies the tool(s) to use. Multiple tools can be combined in a list separated by comma.\nAvailable are: `syfpeithi`, `mhcflurry`, `mhcnuggets-class-1`, `mhcnuggets-class-2`,`netmhcpan-4.0`,`netmhcpan-4.1`,`netmhc-4.0`.",
                     "description": "Specifies the prediction tool(s) to use."
                 },
                 "tool_thresholds": {
@@ -176,6 +176,11 @@
             "description": "External MHC binding prediction software that is not shipped with the pipeline.",
             "default": null,
             "properties": {
+                "external_tools_meta": {
+                    "type": "string",
+                    "default": "${projectDir}/assets/external_tools_meta.json",
+                    "description": "Specifies the path to the JSON file with meta information on external prediction tools."
+                },
                 "netmhc_system": {
                     "type": "string",
                     "default": "linux",


### PR DESCRIPTION
This 
- adds a JSON file for external prediction tools meta data
- adapts the workflow code, schema, etc accordingly

With these changes, it is currently required to specify the version with the external prediction tool by the user (`--tools netmhcpan-4.0`). It might be better to have default versions of the external prediction tools, e.g. if someone specifies `netmhc`, it would use the most recent version.

<!--
# nf-core/epitopeprediction pull request

Many thanks for contributing to nf-core/epitopeprediction!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
