### PR TITLE
Fix execution for multiple samples of same input type

### DIFF
--- a/bin/check_requested_models.py
+++ b/bin/check_requested_models.py
@@ -55,7 +55,7 @@ def __main__():
     parser.add_argument('-t', '--tools', help='Tools requested for peptide predictions', required=True, type=str)
     parser.add_argument('-v', '--versions', help='<Required> File with used software versions.', required=True)
     args = parser.parse_args()
-    selected_methods = [item.split('-')[0] for item in args.tools.split(',')]
+    selected_methods = [item.split('-')[0] if "mhcnuggets" not in item else item for item in args.tools.split(',')]
     with open(args.versions, 'r') as versions_file:
         tool_version = [ (row[0].split()[0], str(row[1])) for row in csv.reader(versions_file, delimiter = ":") ]
         # NOTE this needs to be updated, if a newer version will be available via epytope and should be used in the future

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -1019,7 +1019,7 @@ def __main__():
         else:
             up_db.read_seqs(args.reference_proteome)
 
-    selected_methods = [item.split('-')[0] for item in args.tools.split(',')]
+    selected_methods = [item.split('-')[0] if "mhcnuggets" not in item else item for item in args.tools.split(',')]
     with open(args.versions, 'r') as versions_file:
         tool_version = [ (row[0].split()[0], str(row[1])) for row in csv.reader(versions_file, delimiter = ":") ]
         # NOTE this needs to be updated, if a newer version will be available via epytope and should be used in the future

--- a/modules/local/epytope_peptide_prediction.nf
+++ b/modules/local/epytope_peptide_prediction.nf
@@ -37,6 +37,7 @@ process EPYTOPE_PEPTIDE_PREDICTION {
         argument = "--tool_thresholds ${params.tool_thresholds} " + argument
     }
 
+    def netmhc_paths_string = netmhc_paths.join(",")
     """
     # create folder for MHCflurry downloads to avoid permission problems when running pipeline with docker profile and mhcflurry selected
     mkdir -p mhcflurry-data
@@ -45,7 +46,10 @@ process EPYTOPE_PEPTIDE_PREDICTION {
     export MHCFLURRY_DOWNLOADS_CURRENT_RELEASE=1.4.0
     # Add non-free software to the PATH
     shopt -s nullglob
-    for p in ${netmhc_paths.join('')} ; do export PATH="\$(realpath -s "\$p"):\$PATH"; done
+    IFS=',' read -r -a netmhc_paths_string <<< \"$netmhc_paths_string\"
+    for p in "\${netmhc_paths_string[@]}"; do
+            export PATH="\$(realpath -s "\$p"):\$PATH";
+        done
     shopt -u nullglob
 
     epaa.py --identifier ${splitted.baseName} \

--- a/modules/local/epytope_peptide_prediction.nf
+++ b/modules/local/epytope_peptide_prediction.nf
@@ -8,7 +8,7 @@ process EPYTOPE_PEPTIDE_PREDICTION {
 
     input:
     tuple val(meta), path(splitted), path(software_versions)
-    path netmhc_paths
+    val netmhc_paths
 
     output:
     tuple val(meta), path("*.json"), emit: json
@@ -45,7 +45,7 @@ process EPYTOPE_PEPTIDE_PREDICTION {
     export MHCFLURRY_DOWNLOADS_CURRENT_RELEASE=1.4.0
     # Add non-free software to the PATH
     shopt -s nullglob
-    for p in ${netmhc_paths} ; do export PATH="\$(realpath -s "\$p"):\$PATH"; done
+    for p in ${netmhc_paths.join('')} ; do export PATH="\$(realpath -s "\$p"):\$PATH"; done
     shopt -u nullglob
 
     epaa.py --identifier ${splitted.baseName} \

--- a/modules/local/get_prediction_versions.nf
+++ b/modules/local/get_prediction_versions.nf
@@ -3,8 +3,8 @@ process GET_PREDICTION_VERSIONS {
 
     conda (params.enable_conda ? "bioconda::epytope=3.0.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mulled-v2-c3f301504f7fa2e7bf81c3783de19a9990ea3001:12b1b9f040fd92a80629d58f8a558dde4820eb15-0' :
-        'quay.io/biocontainers/mulled-v2-c3f301504f7fa2e7bf81c3783de19a9990ea3001:12b1b9f040fd92a80629d58f8a558dde4820eb15-0' }"
+        'https://depot.galaxyproject.org/singularity/epytope:3.0.0--pyh5e36f6f_0' :
+        'quay.io/biocontainers/epytope:3.0.0--pyh5e36f6f_0' }"
 
     input:
     val external_tool_versions
@@ -13,7 +13,7 @@ process GET_PREDICTION_VERSIONS {
     path "versions.csv", emit: versions
 
     script:
-    def external_tools = external_tool_versions.join('\n')
+    def external_tools = external_tool_versions.join(",")
 
     """
     cat <<-END_VERSIONS > versions.csv
@@ -22,9 +22,11 @@ process GET_PREDICTION_VERSIONS {
     epytope: \$(python -c "import pkg_resources; print('epytope' + pkg_resources.get_distribution('epytope').version)" | sed 's/^epytope//; s/ .*\$//')
     END_VERSIONS
 
-    if ! [ -z "${external_tools}" ]
-    then
-        echo ${external_tools} >> versions.csv
+    IFS=',' read -r -a external_tools <<< \"$external_tools\"
+    if ! [ -z "${external_tool_versions}" ]; then
+        for TOOL in "\${external_tools[@]}"; do
+            echo "\$TOOL" >> versions.csv
+        done
     fi
     """
 }

--- a/workflows/epitopeprediction.nf
+++ b/workflows/epitopeprediction.nf
@@ -286,7 +286,6 @@ workflow EPITOPEPREDICTION {
     EXTERNAL_TOOLS_IMPORT(
         ch_nonfree_paths
     )
-    ch_exported_tools = EXTERNAL_TOOLS_IMPORT.out.nonfree_tools.ifEmpty([])
 
     /*
     ========================================================================================
@@ -362,7 +361,7 @@ workflow EPITOPEPREDICTION {
             .splitted
             .combine( ch_prediction_tool_versions )
             .transpose(),
-            ch_exported_tools
+            EXTERNAL_TOOLS_IMPORT.out.nonfree_tools.collect().ifEmpty([])
     )
 
     // Run epitope prediction for peptides
@@ -372,7 +371,7 @@ workflow EPITOPEPREDICTION {
             .splitted
             .combine( ch_prediction_tool_versions )
             .transpose(),
-            ch_exported_tools
+            EXTERNAL_TOOLS_IMPORT.out.nonfree_tools.collect().ifEmpty([])
     )
 
     // Run epitope prediction for variants
@@ -383,7 +382,7 @@ workflow EPITOPEPREDICTION {
             .mix( ch_split_variants.splitted )
             .combine( ch_prediction_tool_versions )
             .transpose(),
-            ch_exported_tools
+            EXTERNAL_TOOLS_IMPORT.out.nonfree_tools.collect().ifEmpty([])
     )
 
     // collect prediction script versions


### PR DESCRIPTION
This fixes a bug that occurred during the pipeline execution for multiple samples of the same input type. The prediction process was only executed once in these cases.

<!--
# nf-core/epitopeprediction pull request

Many thanks for contributing to nf-core/epitopeprediction!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
