### PR TITLE
Add threshold function for rank and set affinity as optional

### DIFF
--- a/modules/local/epytope_peptide_prediction.nf
+++ b/modules/local/epytope_peptide_prediction.nf
@@ -37,6 +37,10 @@ process EPYTOPE_PEPTIDE_PREDICTION {
         argument = "--tool_thresholds ${params.tool_thresholds} " + argument
     }
 
+    if (params.affinity_thresholds) {
+        argument = "--affinity_thresholds " + argument
+    }
+
     def netmhc_paths_string = netmhc_paths.join(",")
     """
     # create folder for MHCflurry downloads to avoid permission problems when running pipeline with docker profile and mhcflurry selected

--- a/nextflow.config
+++ b/nextflow.config
@@ -23,6 +23,7 @@ params {
     mhc_class = 1
     tools = 'syfpeithi'
     tool_thresholds = null
+    affinity_thresholds = false
 
     // Options: Filtering
     filter_self = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -116,7 +116,13 @@
                 "tool_thresholds": {
                     "type": "string",
                     "description": "Specifies tool-specific binder thresholds in a JSON file. This can be used to override the given default binder threshold values.",
-                    "help_text": "Default affinity thresholds to determine whether a peptide is considered as a binder are the following:: `syfpeithi` > 50, `mhcflurry` <=500, `mhcnuggets-class-1` <= 500, `mhcnuggets-class-2` <= 500, `netmhc` <= 500, `netmhcpan` <= 500, `netmhcii` <= 500, `netmhciipan` <= 500. Thresholds can be customized in a JSON file: `tool-name:value`"
+                    "help_text": "Default thresholds to determine whether a peptide is considered as a binder are the following: `syfpeithi` > 50, `mhcflurry` <=500, `mhcnuggets-class-1` <= 500, `mhcnuggets-class-2` <= 500, `netmhc` <= 2, `netmhcpan` <= 2, `netmhcii` <= 5, `netmhciipan` <= 5. Note that the default threshold for NetMHC tools is based on the rank metric and remaining predictors is based on affinities. Thresholds can be customized in a JSON file: `tool-name:value`"
+                },
+                "affinity_thresholds": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Specifies the affinity metric instead of the rank metric used for determining whether a peptide is considered as a binder.",
+                    "help_text": "Default affinity thresholds to determine whether a peptide is considered as a binder are the following:: `syfpeithi` > 50, `mhcflurry` <=500, `mhcnuggets-class-1` <= 500, `mhcnuggets-class-2` <= 500, `netmhc` <= 500, `netmhcpan` <= 500, `netmhcii` <= 500, `netmhciipan` <= 500."
                 },
                 "wild_type": {
                     "type": "boolean",


### PR DESCRIPTION
Set rank as default threshold metric for netmhc tools and add option for affinity threshold

<!--
# nf-core/epitopeprediction pull request

Many thanks for contributing to nf-core/epitopeprediction!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
