### PR TITLE
Update to epytope 3.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
         tests:
           [
             "test_variant_tsv",
+            "test_grch38_variant_tsv",
             "test_peptides",
             "test_peptides_h2",
             "test_proteins",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Changed`
 
 - [#152](https://github.com/nf-core/epitopeprediction/pull/152) - Update MultiQC from 1.11 to 1.12
+- [#162](https://github.com/nf-core/epitopeprediction/pull/162) - Use most recent `epytope` release (`3.1.0`)
+- [#162](https://github.com/nf-core/epitopeprediction/pull/162) - Use more recent `Ensembl BioMart` archive release for `GRCh38` (`Ensembl 88`)
 
 ### `Fixed`
 
@@ -36,8 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#121](https://github.com/nf-core/epitopeprediction/pull/121) - Extend full test to cover more test cases
 - [#122](https://github.com/nf-core/epitopeprediction/pull/122) - Update to nf-core template v2.2
 - [#123](https://github.com/nf-core/epitopeprediction/pull/123) - Remove support for outdated external tools `NetMHCII 2.2` and `NetMHCIIpan 3.1`
-- [#162](https://github.com/nf-core/epitopeprediction/pull/162) - Use most recent `epytope` release (`3.1.0`)
-- [#162](https://github.com/nf-core/epitopeprediction/pull/162) - Use more recent `Ensembl BioMart` archive release for `GRCh38` (`Ensembl 88`)
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#122](https://github.com/nf-core/epitopeprediction/pull/122) - Update to nf-core template v2.2
 - [#123](https://github.com/nf-core/epitopeprediction/pull/123) - Remove support for outdated external tools `NetMHCII 2.2` and `NetMHCIIpan 3.1`
 - [#162](https://github.com/nf-core/epitopeprediction/pull/162) - Use most recent `epytope` release (`3.1.0`)
+- [#162](https://github.com/nf-core/epitopeprediction/pull/162) - Use more recent `Ensembl BioMart` archive release for `GRCh38` (`Ensembl 88`)
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#121](https://github.com/nf-core/epitopeprediction/pull/121) - Extend full test to cover more test cases
 - [#122](https://github.com/nf-core/epitopeprediction/pull/122) - Update to nf-core template v2.2
 - [#123](https://github.com/nf-core/epitopeprediction/pull/123) - Remove support for outdated external tools `NetMHCII 2.2` and `NetMHCIIpan 3.1`
+- [#162](https://github.com/nf-core/epitopeprediction/pull/162) - Use most recent `epytope` release (`3.1.0`)
 
 ### `Fixed`
 

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -642,7 +642,7 @@ def get_protein_ids_for_transcripts(idtype, transcripts, ensembl_url, reference)
     else:
         input_lists += [transcripts]
 
-    attribut_swissprot = "uniprot_swissprot_accession" if reference == 'GRCh37' else 'uniprot_swissprot'
+    attribut_swissprot = "uniprot_swissprot_accession" if reference == 'GRCh37' else 'uniprotswissprot'
 
     tsvselect = []
     for l in input_lists:
@@ -659,12 +659,13 @@ def get_protein_ids_for_transcripts(idtype, transcripts, ensembl_url, reference)
 
         tsvselect += [x for x in tsvreader]
 
-    swissProtKey = 'UniProt/SwissProt Accession'
+    swissProtKey = 'UniProt/SwissProt Accession' if reference == 'GRCh37' else 'UniProtKB/Swiss-Prot ID'
 
     if(ENSEMBL):
-        key = 'Ensembl Transcript ID' if reference == 'GRCh37' else 'Transcript ID'
-        protein_key = 'Ensembl Protein ID' if reference == 'GRCh37' else 'Protein ID'
+        key = 'Ensembl Transcript ID' if reference == 'GRCh37' else 'Transcript stable ID'
+        protein_key = 'Ensembl Protein ID' if reference == 'GRCh37' else 'Protein stable ID'
         for dic in tsvselect:
+            print(dic)
             if dic[key] in result:
                 merged = result[dic[key]] + [dic[protein_key]]
                 merged_swissProt = result_swissProt[dic[key]] + [dic[swissProtKey]]
@@ -685,6 +686,7 @@ def get_protein_ids_for_transcripts(idtype, transcripts, ensembl_url, reference)
                 result[dic[key]] = [dic['RefSeq Protein ID [e.g. NP_001005353]']]
                 result_swissProt[dic[key]] = [dic[swissProtKey]]
 
+    print(result)
     return result, result_swissProt
 
 
@@ -987,7 +989,7 @@ def __main__():
 
     metadata = []
     proteins = []
-    references = {'GRCh37': 'http://feb2014.archive.ensembl.org', 'GRCh38': 'http://dec2016.archive.ensembl.org'}
+    references = {'GRCh37': 'http://feb2014.archive.ensembl.org', 'GRCh38': 'http://mar2017.archive.ensembl.org'}
     global transcriptProteinMap
     global transcriptSwissProtMap
 

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -665,7 +665,6 @@ def get_protein_ids_for_transcripts(idtype, transcripts, ensembl_url, reference)
         key = 'Ensembl Transcript ID' if reference == 'GRCh37' else 'Transcript stable ID'
         protein_key = 'Ensembl Protein ID' if reference == 'GRCh37' else 'Protein stable ID'
         for dic in tsvselect:
-            print(dic)
             if dic[key] in result:
                 merged = result[dic[key]] + [dic[protein_key]]
                 merged_swissProt = result_swissProt[dic[key]] + [dic[swissProtKey]]
@@ -686,7 +685,6 @@ def get_protein_ids_for_transcripts(idtype, transcripts, ensembl_url, reference)
                 result[dic[key]] = [dic['RefSeq Protein ID [e.g. NP_001005353]']]
                 result_swissProt[dic[key]] = [dic[swissProtKey]]
 
-    print(result)
     return result, result_swissProt
 
 

--- a/conf/test_grch38_variant_tsv.config
+++ b/conf/test_grch38_variant_tsv.config
@@ -1,0 +1,18 @@
+/*
+ * -------------------------------------------------
+ *  Nextflow config file for running tests
+ * -------------------------------------------------
+ * Defines bundled input files and everything required
+ * to run a fast and simple test. Use as follows:
+ *   nextflow run nf-core/epitopeprediction -profile test_grch38_variant_tsv,<docker/singularity> --outdir <OUTDIR>
+ */
+
+params {
+    max_cpus = 2
+    max_memory = 6.GB
+    max_time = 48.h
+
+    // Input data
+    input = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/sample_sheets/sample_sheet_variants_tab.csv'
+    genome_version = 'GRCh38'
+}

--- a/modules/local/epytope_check_requested_models.nf
+++ b/modules/local/epytope_check_requested_models.nf
@@ -3,8 +3,8 @@ process EPYTOPE_CHECK_REQUESTED_MODELS {
 
     conda (params.enable_conda ? "bioconda::epytope=3.0.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/epytope:3.0.0--pyh5e36f6f_0' :
-        'quay.io/biocontainers/epytope:3.0.0--pyh5e36f6f_0' }"
+        'https://depot.galaxyproject.org/singularity/epytope:3.1.0--pyh5e36f6f_0' :
+        'quay.io/biocontainers/epytope:3.1.0--pyh5e36f6f_0' }"
 
     input:
     tuple val(alleles), path(input_file)

--- a/modules/local/epytope_generate_peptides.nf
+++ b/modules/local/epytope_generate_peptides.nf
@@ -4,8 +4,8 @@ process EPYTOPE_GENERATE_PEPTIDES {
 
     conda (params.enable_conda ? "bioconda::epytope=3.0.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/epytope:3.0.0--pyh5e36f6f_0' :
-        'quay.io/biocontainers/epytope:3.0.0--pyh5e36f6f_0' }"
+        'https://depot.galaxyproject.org/singularity/epytope:3.1.0--pyh5e36f6f_0' :
+        'quay.io/biocontainers/epytope:3.1.0--pyh5e36f6f_0' }"
 
     input:
     tuple val(meta), path(raw)

--- a/modules/local/epytope_peptide_prediction.nf
+++ b/modules/local/epytope_peptide_prediction.nf
@@ -3,8 +3,8 @@ process EPYTOPE_PEPTIDE_PREDICTION {
 
     conda (params.enable_conda ? "conda-forge::coreutils=9.1 conda-forge::tcsh=6.20.00 bioconda::epytope=3.0.0 conda-forge::gawk=5.1.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mulled-v2-3774d4f6160bf3a5a53d47875424448104ba6d22:79da0cdeada554621d205f5713988db45f65fb80-0' :
-        'quay.io/biocontainers/mulled-v2-3774d4f6160bf3a5a53d47875424448104ba6d22:79da0cdeada554621d205f5713988db45f65fb80-0' }"
+        'https://depot.galaxyproject.org/singularity/mulled-v2-3774d4f6160bf3a5a53d47875424448104ba6d22:6c5a7c166277372052f332fd7b94cacc43f5520c-0' :
+        'quay.io/biocontainers/mulled-v2-3774d4f6160bf3a5a53d47875424448104ba6d22:6c5a7c166277372052f332fd7b94cacc43f5520c-0' }"
 
     input:
     tuple val(meta), path(splitted), path(software_versions)

--- a/modules/local/epytope_show_supported_models.nf
+++ b/modules/local/epytope_show_supported_models.nf
@@ -3,8 +3,8 @@ process EPYTOPE_SHOW_SUPPORTED_MODELS {
 
     conda (params.enable_conda ? "bioconda::epytope=3.0.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/epytope:3.0.0--pyh5e36f6f_0' :
-        'quay.io/biocontainers/epytope:3.0.0--pyh5e36f6f_0' }"
+        'https://depot.galaxyproject.org/singularity/epytope:3.1.0--pyh5e36f6f_0' :
+        'quay.io/biocontainers/epytope:3.1.0--pyh5e36f6f_0' }"
 
     input:
     tuple val(meta), path(raw), path(software_versions)

--- a/modules/local/get_prediction_versions.nf
+++ b/modules/local/get_prediction_versions.nf
@@ -3,8 +3,8 @@ process GET_PREDICTION_VERSIONS {
 
     conda (params.enable_conda ? "bioconda::epytope=3.0.0" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/epytope:3.0.0--pyh5e36f6f_0' :
-        'quay.io/biocontainers/epytope:3.0.0--pyh5e36f6f_0' }"
+        'https://depot.galaxyproject.org/singularity/epytope:3.1.0--pyh5e36f6f_0' :
+        'quay.io/biocontainers/epytope:3.1.0--pyh5e36f6f_0' }"
 
     input:
     val external_tool_versions

--- a/nextflow.config
+++ b/nextflow.config
@@ -152,6 +152,7 @@ profiles {
     }
     test { includeConfig 'conf/test.config' }
     test_variant_tsv { includeConfig 'conf/test_variant_tsv.config' }
+    test_grch38_variant_tsv { includeConfig 'conf/test_grch38_variant_tsv.config' }
     test_peptides { includeConfig 'conf/test_peptides.config' }
     test_peptides_h2 { includeConfig 'conf/test_peptides_h2.config' }
     test_proteins { includeConfig 'conf/test_proteins.config' }


### PR DESCRIPTION
This 
- changes the `epytope` container versions to the most recent version `3.1.0` (1)
- changes the `Ensembl BioMart` archive version for GRCh38 (2).

Some background to (2):

At some point we decided to stick to specific archive versions of `Ensembl BioMart` because they kept on changing database fields (names) in new versions which broke our pipeline. Now they retired the archive version for `GRCh38` we were using (Ensembl Archive 87, Dec 2016). For now, I switched to the next version (March 2017) since I assumed this has least changes. I still had to adapt some of the database field names in the `epaa.py`. 

At some point we should switch to more recent version and maybe also think about on how to deal with different (user selected?) versions. The version of the `Ensembl BioMart` can potentially lead to changes in the results, e.g. due to the absence of information on transcripts.

<!--
# nf-core/epitopeprediction pull request

Many thanks for contributing to nf-core/epitopeprediction!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
