### PR TITLE
Increment support of netmhc tools

### DIFF
--- a/assets/external_tools_meta.json
+++ b/assets/external_tools_meta.json
@@ -24,6 +24,13 @@
             "data_url": "https://services.healthtech.dtu.dk/services/NetMHCpan-4.0/data.Linux.tar.gz",
             "data_md5": "26cbbd99a38f6692249442aeca48608f",
             "binary_name": "netMHCpan"
+        },
+        "4.1": {
+            "version": 4.1,
+            "software_md5": "105210d3de5525076347973e9391131c",
+            "data_url": "https://services.healthtech.dtu.dk/services/NetMHCpan-4.1/data.tar.gz",
+            "data_md5": "4bdd3944cb4c5b8ba4d8900dae074c85",
+            "binary_name": "netMHCpan"
         }
     },
     "netmhcpan_darwin": {
@@ -32,6 +39,13 @@
             "software_md5": "042d16b89adcf5656ca4deae06b55cc6",
             "data_url": "https://services.healthtech.dtu.dk/services/NetMHCpan-4.0/data.Darwin.tar.gz",
             "data_md5": "b4eef3c82852d677a98e0f7d753a36e2",
+            "binary_name": "netMHCpan"
+        },
+        "4.1": {
+            "version": 4.0,
+            "software_md5": "5f6eab43feb80a24e32eb02b22e9db5f",
+            "data_url": "https://services.healthtech.dtu.dk/services/NetMHCpan-4.1/data.tar.gz",
+            "data_md5": "4bdd3944cb4c5b8ba4d8900dae074c85",
             "binary_name": "netMHCpan"
         }
     },
@@ -42,14 +56,60 @@
             "data_url": "https://services.healthtech.dtu.dk/services/NetMHCII-2.2/data.tar.gz",
             "data_md5": "11579b61d3bfe13311f7b42fc93b4dd8",
             "binary_name": "netMHCII"
+        },
+        "2.3": {
+            "version": 2.3,
+            "software_md5": "48f118c133990c9458ef82fa23ef901c",
+            "data_url": "https://services.healthtech.dtu.dk/services/NetMHCII-2.3/data.Linux.tar.gz",
+            "data_md5": "675daa3614ab2ffea47751488caffd74",
+            "binary_name": "netMHCII-2.3"
+        }
+    },
+    "netmhcii_darwin": {
+        "2.2": {
+            "version": 2.2,
+            "software_md5": "1dfd0e69346a7e1d6c9b55cfeb70d744",
+            "data_url": "https://services.healthtech.dtu.dk/services/NetMHCII-2.2/data.tar.gz",
+            "data_md5": "11579b61d3bfe13311f7b42fc93b4dd8",
+            "binary_name": "netMHCII"
+        },
+        "2.3": {
+            "version": 2.3,
+            "software_md5": "c944550e4f07a32ac52524a59e5bf89a",
+            "data_url": "https://services.healthtech.dtu.dk/services/NetMHCII-2.3/data.Darwin.tar.gz",
+            "data_md5": "10fd5c94e716f3921d05ec3ffbb919b2",
+            "binary_name": "netMHCII-2.3"
         }
     },
     "netmhciipan": {
-        "3.1": {
-            "version": 3.1,
-            "software_md5": "0962ce799f7a4c9631f8566a55237073",
-            "data_url": "https://services.healthtech.dtu.dk/services/NetMHCIIpan-3.1/data.tar.gz",
-            "data_md5": "f833df245378e60ca6e55748344a36f6",
+        "4.0": {
+            "version": 4.0,
+            "software_md5": "2bbdb95e20e9991be23e80223d216aef",
+            "data_url": "https://services.healthtech.dtu.dk/services/NetMHCIIpan-4.0/data.tar.gz",
+            "data_md5": "ec3032cb66aee20ff0f53ff7f1795f47",
+            "binary_name": "netMHCIIpan"
+        },
+        "4.1": {
+            "version": 4.1,
+            "software_md5": "c70810798334e9f7614899b7ee965a3a",
+            "data_url": "https://services.healthtech.dtu.dk/services/NetMHCIIpan-4.0/data.tar.gz",
+            "data_md5": "ec3032cb66aee20ff0f53ff7f1795f47",
+            "binary_name": "netMHCIIpan"
+        }
+    },
+    "netmhciipan_darwin": {
+        "4.0": {
+            "version": 4.0,
+            "software_md5": "2bbdb95e20e9991be23e80223d216aef",
+            "data_url": "https://services.healthtech.dtu.dk/services/NetMHCIIpan-4.0/data.tar.gz",
+            "data_md5": "ec3032cb66aee20ff0f53ff7f1795f47",
+            "binary_name": "netMHCIIpan"
+        },
+        "4.1": {
+            "version": 4.1,
+            "software_md5": "eaa25d39710da3a8000a5cfd36707f7b",
+            "data_url": "https://services.healthtech.dtu.dk/services/NetMHCIIpan-4.0/data.tar.gz",
+            "data_md5": "ec3032cb66aee20ff0f53ff7f1795f47",
             "binary_name": "netMHCIIpan"
         }
     }

--- a/assets/external_tools_meta.json
+++ b/assets/external_tools_meta.json
@@ -100,7 +100,7 @@
     "netmhciipan_darwin": {
         "4.0": {
             "version": 4.0,
-            "software_md5": "2bbdb95e20e9991be23e80223d216aef",
+            "software_md5": "56ccb1af3795142f2c544c4714f079fa",
             "data_url": "https://services.healthtech.dtu.dk/services/NetMHCIIpan-4.0/data.tar.gz",
             "data_md5": "ec3032cb66aee20ff0f53ff7f1795f47",
             "binary_name": "netMHCIIpan"


### PR DESCRIPTION
This PR increments the number of supported netmhc tools for class 1 and 2 for linux and Mac OS based systems:
- NetMHCpan 4.1
- NetMHCII 2.2 (Mac OS)
- NetMHCII 2.3
- NetMHCIIpan 4.0
- NetMHCIIpan 4.1

For further documentation:
NetMHCIIpan 4.1 (Darwin & Linux) provid the data folder within the software tar, however we did not yet work around this problem. I just thought it would be of nice to have it in order to come up with a solution for this specific version. Meaning the data url and md5 will be deleted most likely.


<!--
# nf-core/epitopeprediction pull request

Many thanks for contributing to nf-core/epitopeprediction!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
