### PR TITLE
Fix bug that results in empty prediction results

### DIFF
--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -1052,16 +1052,16 @@ def __main__():
         else:
             pred_dataframes, statistics, all_peptides_filtered, proteins = make_predictions_from_variants(vl, methods, thresholds, alleles, int(args.min_length), int(args.max_length) + 1, ma, up_db, args.identifier, metadata, transcriptProteinMap)
 
-    no_predictions = False
     # concat dataframes for all peptide lengths
     try:
         complete_df = pd.concat(pred_dataframes, sort=True)
         # replace method names with method names with version
         # complete_df.replace({'method': methods}, inplace=True)
         complete_df['method'] = complete_df['method'].apply(lambda x : x.lower() + '-' + methods[x.lower()] )
+        predictions_available = True
     except:
         complete_df = pd.DataFrame()
-        no_predictions = True
+        predictions_available = False
         logger.error("No predictions available.")
 
 
@@ -1140,7 +1140,7 @@ def __main__():
             complete_df['wt ligand score'] = complete_df.apply(lambda row: create_ligandomics_column_value_for_result(row, lig_id, 0, True), axis=1)
             complete_df['wt ligand intensity'] = complete_df.apply(lambda row: create_ligandomics_column_value_for_result(row, lig_id, 1, True), axis=1)
     # write mutated protein sequences to fasta file
-    if args.fasta_output and not no_predictions:
+    if args.fasta_output and predictions_available:
         with open('{}_prediction_proteins.fasta'.format(args.identifier), 'w') as protein_outfile:
             for p in proteins:
                 variants = []
@@ -1155,7 +1155,8 @@ def __main__():
 
     # write dataframe to tsv
     complete_df.fillna('')
-    if not no_predictions:
+    print(predictions_available)
+    if predictions_available:
         complete_df.to_csv("{}_prediction_results.tsv".format(args.identifier), '\t', index=False)
 
     statistics['number_of_predictions'] = len(complete_df)

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -1051,6 +1051,8 @@ def __main__():
             pred_dataframes, statistics = make_predictions_from_peptides(peptides, methods, thresholds, alleles, up_db, args.identifier, metadata)
         else:
             pred_dataframes, statistics, all_peptides_filtered, proteins = make_predictions_from_variants(vl, methods, thresholds, alleles, int(args.min_length), int(args.max_length) + 1, ma, up_db, args.identifier, metadata, transcriptProteinMap)
+
+    no_predictions = False
     # concat dataframes for all peptide lengths
     try:
         complete_df = pd.concat(pred_dataframes, sort=True)
@@ -1059,7 +1061,9 @@ def __main__():
         complete_df['method'] = complete_df['method'].apply(lambda x : x.lower() + '-' + methods[x.lower()] )
     except:
         complete_df = pd.DataFrame()
+        no_predictions = True
         logger.error("No predictions available.")
+
 
     # include wild type sequences to dataframe if specified
     if args.wild_type:
@@ -1136,7 +1140,7 @@ def __main__():
             complete_df['wt ligand score'] = complete_df.apply(lambda row: create_ligandomics_column_value_for_result(row, lig_id, 0, True), axis=1)
             complete_df['wt ligand intensity'] = complete_df.apply(lambda row: create_ligandomics_column_value_for_result(row, lig_id, 1, True), axis=1)
     # write mutated protein sequences to fasta file
-    if args.fasta_output:
+    if args.fasta_output and not no_predictions:
         with open('{}_prediction_proteins.fasta'.format(args.identifier), 'w') as protein_outfile:
             for p in proteins:
                 variants = []
@@ -1151,7 +1155,8 @@ def __main__():
 
     # write dataframe to tsv
     complete_df.fillna('')
-    complete_df.to_csv("{}_prediction_results.tsv".format(args.identifier), '\t', index=False)
+    if not no_predictions:
+        complete_df.to_csv("{}_prediction_results.tsv".format(args.identifier), '\t', index=False)
 
     statistics['number_of_predictions'] = len(complete_df)
     statistics['number_of_binders'] = len(pos_predictions)

--- a/bin/merge_jsons.py
+++ b/bin/merge_jsons.py
@@ -52,7 +52,7 @@ def __main__():
                     data = combine_dicts(data, json.load(infile))
 
     # merge and write json report
-    data["prediction_methods"] = "".join(set(list(flatten(data["prediction_methods"]))))
+    data["prediction_methods"] = ",".join(set(list(flatten(data["prediction_methods"]))))
     data["number_of_unique_peptides"] = len(
         set(list(flatten(data["number_of_unique_peptides"])))
     )

--- a/modules/local/peptide_prediction.nf
+++ b/modules/local/peptide_prediction.nf
@@ -11,7 +11,7 @@ process PEPTIDE_PREDICTION {
 
     output:
     tuple val(meta), path("*.json"), emit: json
-    tuple val(meta), path("*.tsv"), emit: predicted
+    tuple val(meta), path("*.tsv"), emit: predicted optional true
     tuple val(meta), path("*.fasta"), emit: fasta optional true
     path "versions.yml", emit: versions
 


### PR DESCRIPTION
This fixes a bug that occurs when no predictions are available for one part of the initial input (split input) e.g. for unsupported chromosomes (undefined genomic regions). In this case, the prediction result file of this part will only contain basic information with the corresponding column headers but no predictions. If this files happens to be the first in the `csvtk concat -t` command, the resulting full prediction file will only include the basic information and no predictions.

<!--
# nf-core/epitopeprediction pull request

Many thanks for contributing to nf-core/epitopeprediction!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
