### PR TITLE
Add functionality for prediction with multiple classes in one run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#145](https://github.com/nf-core/epitopeprediction/pull/145) - Add functionality for handling gzipped VCF files for [#143](https://github.com/nf-core/epitopeprediction/issues/143)
 - [#155](https://github.com/nf-core/epitopeprediction/pull/155) - Add functionality for splitting input VCF files by the number of variants [#140](https://github.com/nf-core/epitopeprediction/issues/140)
 - [#161](https://github.com/nf-core/epitopeprediction/pull/161) - Add rank values for prediction threshold (as default) and parameter `use_affinity_thresholds` to use affinity thresholds instead [#160](https://github.com/nf-core/epitopeprediction/issues/160)
+- [#168](https://github.com/nf-core/epitopeprediction/pull/168) - Add parameters to specify MHC class II peptide length (`max_peptide_length_class2` and `min_peptide_length_class2`)
 
 ### `Changed`
 
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#162](https://github.com/nf-core/epitopeprediction/pull/162) - Use most recent `epytope` release (`3.1.0`)
 - [#162](https://github.com/nf-core/epitopeprediction/pull/162) - Use more recent `Ensembl BioMart` archive release for `GRCh38` (`Ensembl 88`)
 - [#163](https://github.com/nf-core/epitopeprediction/pull/163) - Save applied tool thresholds in prediction report
+- [#168](https://github.com/nf-core/epitopeprediction/pull/168) - Use MHC class information specified in sample sheet
 
 ### `Fixed`
 

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -1164,7 +1164,7 @@ def __main__():
     # write dataframe to tsv
     complete_df.fillna('')
     if predictions_available:
-        complete_df.to_csv("{}_prediction_results.tsv".format(args.identifier), '\t', index=False)
+        complete_df.to_csv("{}_prediction_result.tsv".format(args.identifier), '\t', index=False)
 
     statistics['tool_thresholds'] = thresholds
     statistics['number_of_predictions'] = len(complete_df)

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -957,7 +957,7 @@ def __main__():
     parser.add_argument('-g', "--germline_mutations", help="Germline variants")
     parser.add_argument('-i', "--identifier", help="Dataset identifier")
     parser.add_argument('-p', "--peptides", help="File with one peptide per line")
-    parser.add_argument('-c', "--mhcclass", default=1, help="MHC class I or II", type=int)
+    parser.add_argument('-c', "--mhcclass", default=1, help="MHC class I or II")
     parser.add_argument('-l', "--max_length", help="Maximum peptide length")
     parser.add_argument('-ml', "--min_length", help="Minimum peptide length")
     parser.add_argument('-t', "--tools", help="Tools used for peptide predictions", required=True, type=str)
@@ -1050,7 +1050,7 @@ def __main__():
                     raise ValueError('Tool ' + tool +' in specified threshold file is not supported')
 
     # MHC class I or II predictions
-    if args.mhcclass is 1:
+    if args.mhcclass is 'I':
         if args.peptides:
             pred_dataframes, statistics = make_predictions_from_peptides(peptides, methods, thresholds, args.use_affinity_thresholds, alleles, up_db, args.identifier, metadata)
         else:

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -1049,17 +1049,12 @@ def __main__():
                 else:
                     raise ValueError('Tool ' + tool +' in specified threshold file is not supported')
 
-    # MHC class I or II predictions
-    if args.mhcclass is 'I':
-        if args.peptides:
-            pred_dataframes, statistics = make_predictions_from_peptides(peptides, methods, thresholds, args.use_affinity_thresholds, alleles, up_db, args.identifier, metadata)
-        else:
-            pred_dataframes, statistics, all_peptides_filtered, proteins = make_predictions_from_variants(vl, methods, thresholds, args.use_affinity_thresholds, alleles, int(args.min_length), int(args.max_length) + 1, ma, up_db, args.identifier, metadata, transcriptProteinMap)
+    # Distinguish between prediction for peptides and variants
+    if args.peptides:
+        pred_dataframes, statistics = make_predictions_from_peptides(peptides, methods, thresholds, args.use_affinity_thresholds, alleles, up_db, args.identifier, metadata)
     else:
-        if args.peptides:
-            pred_dataframes, statistics = make_predictions_from_peptides(peptides, methods, thresholds, args.use_affinity_thresholds, alleles, up_db, args.identifier, metadata)
-        else:
-            pred_dataframes, statistics, all_peptides_filtered, proteins = make_predictions_from_variants(vl, methods, thresholds, args.use_affinity_thresholds, alleles, int(args.min_length), int(args.max_length) + 1, ma, up_db, args.identifier, metadata, transcriptProteinMap)
+        pred_dataframes, statistics, all_peptides_filtered, proteins = make_predictions_from_variants(vl, methods, thresholds, args.use_affinity_thresholds, alleles, int(args.min_length), int(args.max_length) + 1, ma, up_db, args.identifier, metadata, transcriptProteinMap)
+
     # concat dataframes for all peptide lengths
     try:
         complete_df = pd.concat(pred_dataframes, sort=True)

--- a/bin/merge_jsons.py
+++ b/bin/merge_jsons.py
@@ -56,6 +56,8 @@ def __main__():
 
     # merge and write json report
     data["prediction_methods"] = ",".join(set(list(flatten(data["prediction_methods"]))))
+    # tool thresholds is the same for all runs i.e. for all JSON parts
+    data["tool_thresholds"] = json_content["tool_thresholds"]
     data["number_of_unique_peptides"] = len(
         set(list(flatten(data["number_of_unique_peptides"])))
     )

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -43,7 +43,7 @@ process {
             path: { "${params.outdir}/reports" },
             mode: params.publish_dir_mode
         ]
-        ext.args = "--tools ${params.tools} --max_length ${params.max_peptide_length} --min_length ${params.min_peptide_length} "
+        ext.args = "--tools ${params.tools} "
     }
 
     withName: EPYTOPE_CHECK_REQUESTED_MODELS_PEP {
@@ -51,7 +51,7 @@ process {
             path: { "${params.outdir}/reports" },
             mode: params.publish_dir_mode
         ]
-        ext.args = "--tools ${params.tools} --max_length ${params.max_peptide_length} --min_length ${params.min_peptide_length} --peptides "
+        ext.args = "--tools ${params.tools} --peptides "
     }
 
     withName: EPYTOPE_GENERATE_PEPTIDES {
@@ -59,7 +59,7 @@ process {
             path: { "${params.outdir}/generated_peptides/${meta.sample}" },
             mode: params.publish_dir_mode
         ]
-        ext.args = "--max_length ${params.max_peptide_length} --min_length ${params.min_peptide_length} "
+        ext.args = ''
     }
 
     withName: SPLIT_PEPTIDES {
@@ -76,7 +76,7 @@ process {
             mode: params.publish_dir_mode
         ]
         // Argument list needs to end with --peptides
-        ext.args = "--tools ${params.tools} --mhcclass ${params.mhc_class} --max_length ${params.max_peptide_length} --min_length ${params.min_peptide_length} --reference ${params.genome_version} --peptides"
+        ext.args = "--reference ${params.genome_version} --peptides"
     }
 
     withName: EPYTOPE_PEPTIDE_PREDICTION_PEP {
@@ -85,7 +85,7 @@ process {
             mode: params.publish_dir_mode
         ]
         // Argument list needs to end with --peptides
-        ext.args = "--tools ${params.tools} --mhcclass ${params.mhc_class} --max_length ${params.max_peptide_length} --min_length ${params.min_peptide_length} --reference ${params.genome_version} --peptides"
+        ext.args = "--reference ${params.genome_version} --peptides"
     }
 
     withName: EPYTOPE_PEPTIDE_PREDICTION_VAR {
@@ -94,7 +94,7 @@ process {
             mode: params.publish_dir_mode
         ]
         // Argument list needs to end with --somatic_mutation
-        ext.args = "--tools ${params.tools} --mhcclass ${params.mhc_class} --max_length ${params.max_peptide_length} --min_length ${params.min_peptide_length} --reference ${params.genome_version} --somatic_mutation"
+        ext.args = "--reference ${params.genome_version} --somatic_mutation"
     }
 
     withName: MERGE_JSON_SINGLE {

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -17,4 +17,5 @@ params {
     // Input data for full size test
     input = 'https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/sample_sheets/sample_sheet_full_test.csv'
     schema_ignore_params = 'genomes,input_paths'
+    tools = 'syfpeithi,mhcnuggets-class-2'
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -45,11 +45,13 @@ Protein input is supported in `FASTA` format.
 The `sample` identifiers are used to determine which sample belongs to the input file. Below is an example for the same sample with different input files that can be used:
 
 ```console
-sample,alleles,filename
-GBM_1,A*01:01;A*02:01;B*07:02;B*24:02;C*03:01;C*04:01,gbm_1_variants.vcf(.gz)
-GBM_1,A*01:01;A*02:01;B*07:02;B*24:02;C*03:01;C*04:01,gbm_1_peptides.tsv
-GBM_1,A*01:01;A*02:01;B*07:02;B*24:02;C*03:01;C*04:01,gbm_1_proteins.fasta
+sample,alleles,mhc_class,filename
+GBM_1,A*01:01;A*02:01;B*07:02;B*24:02;C*03:01;C*04:01,I,gbm_1_variants.vcf(.gz)
+GBM_1,A*01:01;A*02:01;B*07:02;B*24:02;C*03:01;C*04:01,I,gbm_1_peptides.tsv
+GBM_1,A*01:01;A*02:01;B*07:02;B*24:02;C*03:01;C*04:01,I,gbm_1_proteins.fasta
 ```
+
+You can also perform predictions for multiple MHC classes (`I`, `II` and `H-2`) in the same run by specifying the value in the corresponding column (one value per row). Please make sure to select the alleles accordingly.
 
 ### Full samplesheet
 
@@ -58,17 +60,18 @@ The pipeline accepts allele information in a file or as string in the sampleshee
 A final samplesheet file consisting of both allele data and different input types of two samples may look something like the one below.
 
 ```console
-sample,alleles,filename
-GBM_1,A*01:01;A*02:01;B*07:02;B*24:02;C*03:01;C*04:01,gbm_1_variants.vcf
-GBM_1,A*02:01;A*24:01;B*07:02;B*08:01;C*04:01;C*07:01,gbm_1_peptides.vcf
-GBM_1,A*01:01;A*24:01;B*07:02;B*08:01;C*03:01;C*07:01,gbm_1_proteins.vcf
-GBM_2,alleles.txt,gbm_2_variants.vcf
+sample,alleles,mhc_class,filename
+GBM_1,A*01:01;A*02:01;B*07:02;B*24:02;C*03:01;C*04:01,I,gbm_1_variants.vcf
+GBM_1,A*02:01;A*24:01;B*07:02;B*08:01;C*04:01;C*07:01,I,gbm_1_peptides.vcf
+GBM_1,A*01:01;A*24:01;B*07:02;B*08:01;C*03:01;C*07:01,I,gbm_1_proteins.vcf
+GBM_2,alleles.txt,I,gbm_2_variants.vcf
 ```
 
 | Column     | Description                                                                                                                                                                            |
 | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `sample`   | Custom sample name. This entry will be identical for multiple sequencing libraries/runs from the same sample. Spaces in sample names are automatically converted to underscores (`_`). |
-| `alleles`  | A string that consists of the patient's alleles (separated by ";"), or a full path to a allele ".txt" file where each allele is saved on a row.                                        |
+| `alleles`  | A string that consists of the patient's alleles (separated by ";"), or a full path to a allele ".txt" file where each allele is saved on a row.
+| `mhc_class`  | Specifies the MHC class for which the prediction should be performed. Valid values are: `I`, `II` and `H-2` (mouse).                                             |
 | `filename` | Full path to a variant/peptide or protein file (".vcf", ".vcf.gz", "tsv", "fasta", or "GSvar").                                                                                        |
 
 An [example samplesheet](../assets/samplesheet.csv) has been provided with the pipeline.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -67,12 +67,12 @@ GBM_1,A*01:01;A*24:01;B*07:02;B*08:01;C*03:01;C*07:01,I,gbm_1_proteins.vcf
 GBM_2,alleles.txt,I,gbm_2_variants.vcf
 ```
 
-| Column     | Description                                                                                                                                                                            |
-| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `sample`   | Custom sample name. This entry will be identical for multiple sequencing libraries/runs from the same sample. Spaces in sample names are automatically converted to underscores (`_`). |
-| `alleles`  | A string that consists of the patient's alleles (separated by ";"), or a full path to a allele ".txt" file where each allele is saved on a row.
-| `mhc_class`  | Specifies the MHC class for which the prediction should be performed. Valid values are: `I`, `II` and `H-2` (mouse).                                             |
-| `filename` | Full path to a variant/peptide or protein file (".vcf", ".vcf.gz", "tsv", "fasta", or "GSvar").                                                                                        |
+| Column      | Description                                                                                                                                                                            |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sample`    | Custom sample name. This entry will be identical for multiple sequencing libraries/runs from the same sample. Spaces in sample names are automatically converted to underscores (`_`). |
+| `alleles`   | A string that consists of the patient's alleles (separated by ";"), or a full path to a allele ".txt" file where each allele is saved on a row.                                        |
+| `mhc_class` | Specifies the MHC class for which the prediction should be performed. Valid values are: `I`, `II` and `H-2` (mouse).                                                                   |
+| `filename`  | Full path to a variant/peptide or protein file (".vcf", ".vcf.gz", "tsv", "fasta", or "GSvar").                                                                                        |
 
 An [example samplesheet](../assets/samplesheet.csv) has been provided with the pipeline.
 

--- a/modules/local/cat_files.nf
+++ b/modules/local/cat_files.nf
@@ -10,13 +10,15 @@ process CAT_FILES {
     tuple val(meta), path(input)
 
     output:
-    tuple val(meta), path("*_prediction.*"), emit: output
+    tuple val(meta), path("*_prediction*"), emit: output
 
     script:
     def fileExt = input[0].name.tokenize("\\.")[-1]
-    prefix = task.ext.suffix ? "${meta.sample}_${task.ext.suffix}" : "${meta.sample}"
+    def prefix = task.ext.suffix ? "${meta.sample}_${task.ext.suffix}" : "${meta.sample}"
+    def type = fileExt == "tsv" ? "prediction_result" : "prediction_proteins"
+
 
     """
-    cat $input > ${prefix}_prediction.${fileExt}
+    cat $input > ${prefix}_${type}.${fileExt}
     """
 }

--- a/modules/local/epytope_generate_peptides.nf
+++ b/modules/local/epytope_generate_peptides.nf
@@ -16,9 +16,13 @@ process EPYTOPE_GENERATE_PEPTIDES {
 
     script:
     def prefix = task.ext.suffix ? "${meta.sample}_${task.ext.suffix}" : "${meta.sample}_peptides"
+    def min_length = (meta.mhcclass == "I") ? params.min_peptide_length : params.min_peptide_length_class2
+    def max_length = (meta.mhcclass == "I") ? params.max_peptide_length : params.max_peptide_length_class2
 
     """
     gen_peptides.py --input ${raw} \\
+    --max_length ${max_length} \\
+    --min_length ${min_length} \\
     --output '${prefix}.tsv' \\
     $task.ext.args
 

--- a/modules/local/epytope_peptide_prediction.nf
+++ b/modules/local/epytope_peptide_prediction.nf
@@ -42,6 +42,19 @@ process EPYTOPE_PEPTIDE_PREDICTION {
     }
 
     def netmhc_paths_string = netmhc_paths.join(",")
+    def tools_split = params.tools.split(',')
+    def class1_tools = tools_split.findAll { ! it.matches('.*(?i)(class-2|ii).*') }
+    def class2_tools = tools_split.findAll { it.matches('.*(?i)(syf|class-2|ii).*') }
+
+    if (((meta.mhcclass == "I") & class1_tools.empty) | ((meta.mhcclass == "II") & class2_tools.empty)) {
+        exit 1, "No tools specified for mhc class ${meta.mhcclass}"
+    }
+
+    def min_length = (meta.mhcclass == "I") ? params.min_peptide_length : params.min_peptide_length_class2
+    def max_length = (meta.mhcclass == "I") ? params.max_peptide_length : params.max_peptide_length_class2
+
+    def tools_to_use = ((meta.mhcclass == "I") | (meta.mhcclass == "H-2")) ? class1_tools.join(',') : class2_tools.join(',')
+
     """
     # create folder for MHCflurry downloads to avoid permission problems when running pipeline with docker profile and mhcflurry selected
     mkdir -p mhcflurry-data
@@ -58,6 +71,10 @@ process EPYTOPE_PEPTIDE_PREDICTION {
 
     epaa.py --identifier ${splitted.baseName} \
         --alleles '${meta.alleles}' \
+        --mhcclass '${meta.mhcclass}' \
+        --tools '${tools_to_use}' \
+        --max_length ${max_length} \
+        --min_length ${min_length} \
         --versions ${software_versions} \
         ${argument} ${splitted}
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -20,7 +20,6 @@ params {
     genome_version = 'GRCh37'
 
     // Options: Predictions
-    mhc_class = 1
     tools = 'syfpeithi'
     tool_thresholds = null
     use_affinity_thresholds = false
@@ -38,8 +37,10 @@ params {
     netmhcii_path = null
 
     // Options: Peptides
-    max_peptide_length = (mhc_class == 1) ? 11 : 16
-    min_peptide_length = (mhc_class == 1) ? 8 : 15
+    max_peptide_length = 11
+    min_peptide_length = 8
+    max_peptide_length_class2 = 16
+    min_peptide_length_class2 = 15
 
     // Options: Annotation
     proteome = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -10,7 +10,10 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": ["input", "outdir"],
+            "required": [
+                "input",
+                "outdir"
+            ],
             "properties": {
                 "input": {
                     "type": "string",
@@ -52,7 +55,10 @@
                     "type": "string",
                     "default": "GRCh37",
                     "help_text": "This defines against which human reference genome the pipeline performs the analysis including the incorporation of genetic variants e.g..",
-                    "enum": ["GRCh37", "GRCh38"],
+                    "enum": [
+                        "GRCh37",
+                        "GRCh38"
+                    ],
                     "description": "Specifies  the human reference genome version."
                 },
                 "proteome": {
@@ -88,13 +94,6 @@
                     "description": "Filter against human proteome.",
                     "help_text": "Specifies that peptides should be filtered against the specified human proteome references."
                 },
-                "mhc_class": {
-                    "type": "integer",
-                    "default": 1,
-                    "description": "MHC class for prediction.",
-                    "help_text": "Specifies whether the predictions should be done for MHC class I or class II.",
-                    "enum": [1, 2]
-                },
                 "max_peptide_length": {
                     "type": "integer",
                     "default": 11,
@@ -106,6 +105,16 @@
                     "default": 8,
                     "description": "Specifies the minimum peptide length.",
                     "help_text": "Specifies the minimum peptide length (not applied when `--peptides` is specified). Default: MCH class I: 8 aa, MHC class II: 15 aa"
+                },
+                "max_peptide_length_class2": {
+                    "type": "integer",
+                    "default": 16,
+                    "description": "Specifies the maximum peptide length for MHC class II peptides."
+                },
+                "min_peptide_length_class2": {
+                    "type": "integer",
+                    "default": 15,
+                    "description": "Specifies the minimum peptide length for MHC class II peptides."
                 },
                 "tools": {
                     "type": "string",
@@ -120,7 +129,6 @@
                 },
                 "use_affinity_thresholds": {
                     "type": "boolean",
-                    "default": false,
                     "description": "Specifies the affinity metric instead of the rank metric used for determining whether a peptide is considered as a binder.",
                     "help_text": "Switches the prediction metric of netMHC tools from rank to affinity. Default: `netmhc` <= 500, `netmhcpan` <= 500, `netmhcii` <= 500, `netmhciipan` <= 500."
                 },
@@ -317,7 +325,14 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
+                    "enum": [
+                        "symlink",
+                        "rellink",
+                        "link",
+                        "copy",
+                        "copyNoFollow",
+                        "move"
+                    ],
                     "hidden": true
                 },
                 "email_on_fail": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -10,10 +10,7 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": [
-                "input",
-                "outdir"
-            ],
+            "required": ["input", "outdir"],
             "properties": {
                 "input": {
                     "type": "string",
@@ -55,10 +52,7 @@
                     "type": "string",
                     "default": "GRCh37",
                     "help_text": "This defines against which human reference genome the pipeline performs the analysis including the incorporation of genetic variants e.g..",
-                    "enum": [
-                        "GRCh37",
-                        "GRCh38"
-                    ],
+                    "enum": ["GRCh37", "GRCh38"],
                     "description": "Specifies  the human reference genome version."
                 },
                 "proteome": {
@@ -325,14 +319,7 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": [
-                        "symlink",
-                        "rellink",
-                        "link",
-                        "copy",
-                        "copyNoFollow",
-                        "move"
-                    ],
+                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
                     "hidden": true
                 },
                 "email_on_fail": {

--- a/workflows/epitopeprediction.nf
+++ b/workflows/epitopeprediction.nf
@@ -187,15 +187,13 @@ workflow EPITOPEPREDICTION {
 
     // perform the check requested models on the variant files
     EPYTOPE_CHECK_REQUESTED_MODELS(
-        ch_samples_uncompressed.variant
-            .mix(ch_samples_uncompressed.protein),
+        ch_samples_uncompressed.variant,
         ch_prediction_tool_versions
     )
 
     // perform the check requested models on the protein files
     EPYTOPE_CHECK_REQUESTED_MODELS_PROTEIN(
-        ch_samples_uncompressed.variant
-            .mix(ch_samples_uncompressed.protein),
+        ch_samples_uncompressed.protein,
         ch_prediction_tool_versions
     )
 


### PR DESCRIPTION
This
- adds the functionality to process MHC class information given in the sample sheets in order to perform prediction for multiple mhc classes in the same run
- introduces two new parameters  (`max_peptide_length_class2`,`min_peptide_length_class2`) for providing peptide length for class I and class II peptides independently 
- removes the parameter `mhc_class`
- extends documentation

<!--
# nf-core/epitopeprediction pull request

Many thanks for contributing to nf-core/epitopeprediction!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
-->
<!-- markdownlint-disable ul-indent -->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
