### PR TITLE
Fix external tool version

### DIFF
--- a/assets/external_tools_meta.json
+++ b/assets/external_tools_meta.json
@@ -42,7 +42,7 @@
             "binary_name": "netMHCpan"
         },
         "4.1": {
-            "version": 4.0,
+            "version": 4.1,
             "software_md5": "5f6eab43feb80a24e32eb02b22e9db5f",
             "data_url": "https://services.healthtech.dtu.dk/services/NetMHCpan-4.1/data.tar.gz",
             "data_md5": "4bdd3944cb4c5b8ba4d8900dae074c85",


### PR DESCRIPTION
This changes the version property of `netmhcpan_darwin 4.1` to the correct one. 

<!--
# nf-core/epitopeprediction pull request

Many thanks for contributing to nf-core/epitopeprediction!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
