### PR TITLE
New structure of mhc binding subworkflow 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,3 +123,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## v1.0.0 - purple-nickel-shrimp - 2019-12-05
 
 - Initial release of nf-core/epitopeprediction, created with the [nf-core](http://nf-co.re/) template.
+
+### `Changed`
+
+- [#206](https://github.com/nf-core/epitopeprediction/issues/206) - Update the row checker class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v2.2.2dev - 2023-07-12
+## v2.2.2dev - 2023-08-29
 
 ### `Changed`
 
 - [203](https://github.com/nf-core/epitopeprediction/pull/203) - Update to nf-core template `2.9`
 - [203](https://github.com/nf-core/epitopeprediction/pull/203) - Update to nf-core template `2.8`
+- [#206](https://github.com/nf-core/epitopeprediction/issues/206) - Update the row checker class.
 
 ## v2.2.1 - WaldhaeuserOst Hotfix - 2023-03-16
 
@@ -123,7 +124,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## v1.0.0 - purple-nickel-shrimp - 2019-12-05
 
 - Initial release of nf-core/epitopeprediction, created with the [nf-core](http://nf-co.re/) template.
-
-### `Changed`
-
-- [#206](https://github.com/nf-core/epitopeprediction/issues/206) - Update the row checker class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [203](https://github.com/nf-core/epitopeprediction/pull/203) - Update to nf-core template `2.9`
 - [203](https://github.com/nf-core/epitopeprediction/pull/203) - Update to nf-core template `2.8`
 - [#206](https://github.com/nf-core/epitopeprediction/issues/206) - Update the row checker class.
+- [#205](https://github.com/nf-core/epitopeprediction/issues/205) - Update general structure of MHC binding subworkflow
 
 ## v2.2.1 - WaldhaeuserOst Hotfix - 2023-03-16
 

--- a/bin/check_requested_models.py
+++ b/bin/check_requested_models.py
@@ -6,6 +6,7 @@ import sys
 import csv
 import argparse
 import logging
+import urllib.request
 
 from epytope.Core.Allele import Allele
 from epytope.Core.Peptide import Peptide
@@ -74,7 +75,12 @@ def __main__():
         }
 
     # get the alleles
-    alleles = [Allele(a) for a in args.alleles.split(";")]
+    if args.alleles.startswith("http"):
+        alleles = [Allele(a) for a in urllib.request.urlopen(args.alleles).read().decode("utf-8").splitlines()]
+    elif args.alleles.endswith(".txt"):
+        alleles = [Allele(a) for a in open(args.alleles, "r").read().splitlines()]
+    else:
+        alleles = [Allele(a) for a in args.alleles.split(";")]
 
     peptide_lengths = []
     if args.peptides:

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -157,7 +157,6 @@ def get_file_type(file):
         elif extension in ["tsv", "GSvar"]:
             # Check if the file is a variant annotation file or a peptide file
             header_columns = [col.strip() for col in file[0].split("\t")]
-            print(header_columns)
 
             required_variant_columns = ["#chr", "start", "end"]
 
@@ -275,7 +274,8 @@ def check_samplesheet(file_in, file_out):
         out_dir = os.path.dirname(file_out)
         make_dir(out_dir)
         with open(file_out, "w") as fout:
-            fout.write(",".join(valid_header) + ",file_type\n")
+            valid_header = valid_header.append('file_type')
+            fout.write(",".join(valid_header) + "\n")
             for row in rows:
                 fout.write(",".join(row) + "\n")
 

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -274,7 +274,8 @@ def check_samplesheet(file_in, file_out):
         out_dir = os.path.dirname(file_out)
         make_dir(out_dir)
         with open(file_out, "w") as fout:
-            fout.write(",".join(valid_header) + ",file_type\n")
+            valid_header.append('file_type')
+            fout.write(",".join(valid_header) + "\n")
             for row in rows:
                 fout.write(",".join(row) + "\n")
 

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -274,7 +274,7 @@ def check_samplesheet(file_in, file_out):
         out_dir = os.path.dirname(file_out)
         make_dir(out_dir)
         with open(file_out, "w") as fout:
-            valid_header.append('file_type')
+            valid_header.append("file_type")
             fout.write(",".join(valid_header) + "\n")
             for row in rows:
                 fout.write(",".join(row) + "\n")

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+# Written by Jonas Scheid, Christopher Mohr and released under the MIT license.
 
 import argparse
 import logging

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -154,12 +154,13 @@ def get_file_type(file):
         elif extension in ['tsv', 'GSvar']:
             # Check if the file is a variant annotation file or a peptide file
             header_columns = [col.strip() for col in file[0].split('\t')]
+            print(header_columns)
 
             required_variant_columns = ['#chr', 'start', 'end']
 
             file_type = 'peptide'
 
-            if all(col in required_variant_columns for col in header_columns):
+            if all(col in header_columns for col in required_variant_columns):
                 file_type = 'variant'
             elif 'sequence' not in header_columns:
                 raise AssertionError("Peptide input file does not contain mandatory column 'sequence'")

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -251,6 +251,7 @@ def check_samplesheet(file_in, file_out):
         ## Check header
         valid_header = ["sample", "alleles", "mhc_class", "filename"]
         header = [x.strip('"') for x in samplesheet.readline().strip().split(",")]
+        print(header)
         if len(header) != 4:
             raise ValueError(
                 f"Invalid number of header columns! Make sure the samplesheet is properly comma-separated."
@@ -274,8 +275,7 @@ def check_samplesheet(file_in, file_out):
         out_dir = os.path.dirname(file_out)
         make_dir(out_dir)
         with open(file_out, "w") as fout:
-            valid_header = valid_header.append('file_type')
-            fout.write(",".join(valid_header) + "\n")
+            fout.write(",".join(valid_header) + ",file_type\n")
             for row in rows:
                 fout.write(",".join(row) + "\n")
 

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -8,32 +8,33 @@ import re
 import sys
 import errno
 import re
+import csv
 from pathlib import Path
-
-logger = logging.getLogger()
-
+import urllib.request
 
 class RowChecker:
     """
     Define a service that can validate and transform each given row.
 
     Attributes:
-        modified (list): A list of dicts, where each dict corresponds to a previously
+        rows (list): A list of dicts, where each dict corresponds to a previously
             validated and transformed row. The order of rows is maintained.
 
     """
 
     VALID_FORMATS = (
-        ".fq.gz",
-        ".fastq.gz",
+        ".tsv",
+        ".fasta",
+        ".vcf",
+        "GSvar"
     )
 
     def __init__(
         self,
-        sample_col="sample",
-        first_col="fastq_1",
-        second_col="fastq_2",
-        single_col="single_end",
+        sample_col=0,
+        alleles_col=1,
+        mhc_class_col=2,
+        filename_col=3,
         **kwargs,
     ):
         """
@@ -42,124 +43,131 @@ class RowChecker:
         Args:
             sample_col (str): The name of the column that contains the sample name
                 (default "sample").
-            first_col (str): The name of the column that contains the first (or only)
-                FASTQ file path (default "fastq_1").
-            second_col (str): The name of the column that contains the second (if any)
-                FASTQ file path (default "fastq_2").
-            single_col (str): The name of the new column that will be inserted and
-                records whether the sample contains single- or paired-end sequencing
-                reads (default "single_end").
+            alleles_col (str): The name of the column that contains the MHC alleles.
+            mhc_class_col (str): The name of the column that contains the MHC class.
+            filename_col (str): The name of the column that contains the filename.
 
         """
         super().__init__(**kwargs)
         self._sample_col = sample_col
-        self._first_col = first_col
-        self._second_col = second_col
-        self._single_col = single_col
+        self._alleles_col = alleles_col
+        self._mhc_class_col = mhc_class_col
+        self._filename_col = filename_col
         self._seen = set()
-        self.modified = []
+        self.rows = []
 
-    def validate_and_transform(self, row):
+    def validate(self, row):
         """
-        Perform all validations on the given row and insert the read pairing status.
+        Perform all validations on the given row.
 
         Args:
             row (dict): A mapping from column headers (keys) to elements of that row
                 (values).
 
         """
+        self._validate_row_length(row)
         self._validate_sample(row)
-        self._validate_first(row)
-        self._validate_second(row)
-        self._validate_pair(row)
-        self._seen.add((row[self._sample_col], row[self._first_col]))
-        self.modified.append(row)
+        self._validate_allele(row)
+        self._validate_mhc_class(row)
+        self._validate_file(row[self._filename_col])
+        self._seen.add((row[self._sample_col], row[self._alleles_col], row[self._mhc_class_col], row[self._filename_col]))
+        self.rows.append(row)
+        self._validate_unique_row()
+        self._validate_unique_sample()
 
     def _validate_sample(self, row):
         """Assert that the sample name exists and convert spaces to underscores."""
         if len(row[self._sample_col]) <= 0:
-            raise AssertionError("Sample input is required.")
-        # Sanitize samples slightly.
-        row[self._sample_col] = row[self._sample_col].replace(" ", "_")
+            raise AssertionError(f"Sample input is required.\nLine: {row}")
 
-    def _validate_first(self, row):
-        """Assert that the first FASTQ entry is non-empty and has the right format."""
-        if len(row[self._first_col]) <= 0:
-            raise AssertionError("At least the first FASTQ file is required.")
-        self._validate_fastq_format(row[self._first_col])
+    def _validate_allele(self, row):
+        """Assert that the alleles have the right format."""
+        valid_class1_loci = ["A*", "B*", "C*", "E*", "G*"]
+        valid_class2_loci = ["DR", "DP", "DQ"]
 
-    def _validate_second(self, row):
-        """Assert that the second FASTQ entry has the right format if it exists."""
-        if len(row[self._second_col]) > 0:
-            self._validate_fastq_format(row[self._second_col])
+        if len(row[self._alleles_col]) <= 0:
+            raise AssertionError(f"No alleles specified.\nLine: {row}")
+        if (
+                not os.path.isfile(row[self._alleles_col])
+                and (row[self._mhc_class_col] == "I"
+                and any(substring in row[self._alleles_col] for substring in valid_class2_loci))
+                or (row[self._mhc_class_col] == "II"
+                and any(substring in row[self._alleles_col] for substring in valid_class1_loci))
+            ):
+                raise AssertionError(f"Samplesheet contains invalid mhc class and allele combination!\nLine: {row} \
+                                      \nValid loci: {valid_class1_loci if row[self._mhc_class_col] == 'I' else valid_class2_loci}")
 
-    def _validate_pair(self, row):
-        """Assert that read pairs have the same file extension. Report pair status."""
-        if row[self._first_col] and row[self._second_col]:
-            row[self._single_col] = False
-            first_col_suffix = Path(row[self._first_col]).suffixes[-2:]
-            second_col_suffix = Path(row[self._second_col]).suffixes[-2:]
-            if first_col_suffix != second_col_suffix:
-                raise AssertionError("FASTQ pairs must have the same file extensions.")
-        else:
-            row[self._single_col] = True
+    def _validate_mhc_class(self, row):
+        """Assert that the mhc_class has the right format."""
+        valid_classes = ["I","II","H-2"]
+        if row[self._mhc_class_col] not in valid_classes:
+            raise AssertionError(f"MHC class must be one of: {valid_classes}\nLine: {row}")
 
-    def _validate_fastq_format(self, filename):
+
+    def _validate_file(self, filename):
         """Assert that a given filename has one of the expected FASTQ extensions."""
         if not any(filename.endswith(extension) for extension in self.VALID_FORMATS):
             raise AssertionError(
-                f"The FASTQ file has an unrecognized extension: {filename}\n"
+                f"The input file has an unrecognized extension: {filename}\n"
                 f"It should be one of: {', '.join(self.VALID_FORMATS)}"
             )
 
-    def validate_unique_samples(self):
-        """
-        Assert that the combination of sample name and FASTQ filename is unique.
+    def _validate_row_length(self, row):
+        """Assert the row length."""
+        if len(row) != 4:
+            raise AssertionError(f"Invalid row length: {len(row)}\nLine: {row}.")
 
-        In addition to the validation, also rename all samples to have a suffix of _T{n}, where n is the
-        number of times the same sample exist, but with different FASTQ files, e.g., multiple runs per experiment.
+    def _validate_unique_row(self):
+        """Assert that the combination of sample name, alleles, mhc_class and filename is unique."""
+        if len(self._seen) != len(self.rows) and len(self.rows) > 1:
+            raise AssertionError(f"Duplicate row found: {self.rows[-1]}")
 
-        """
-        if len(self._seen) != len(self.modified):
-            raise AssertionError("The pair of sample name and FASTQ must be unique.")
-        seen = Counter()
-        for row in self.modified:
-            sample = row[self._sample_col]
-            seen[sample] += 1
-            row[self._sample_col] = f"{sample}_T{seen[sample]}"
-
-
-def read_head(handle, num_lines=10):
-    """Read the specified number of lines from the current position in the file."""
-    lines = []
-    for idx, line in enumerate(handle):
-        if idx == num_lines:
-            break
-        lines.append(line)
-    return "".join(lines)
+    def _validate_unique_sample(self):
+        """ Assert that the combination sample names are unique."""
+        sample_names = [row[self._sample_col] for row in self.rows]
+        if len(set(sample_names)) != len(sample_names):
+            raise AssertionError(f"Duplicate sample name found: {self.rows[-1]}")
 
 
-def sniff_format(handle):
-    """
-    Detect the tabular format.
+def get_file_type(file):
+    """ Read file extension and return file type"""
+    extension = file.split(".")[-1]
+    #check input file is empty
+    #it needs to be distinguished if there's a given local file or internet address
+    if str(file).startswith("http"):
+        with urllib.request.urlopen(file) as response:
+            file = response.read().decode('utf-8').split('\n')
+            if len(file) == 0:
+                raise AssertionError(f"Input file {file} is empty.")
+    else:
+        file = open(file, 'r').readlines()
+        if file == 0:
+            raise AssertionError(f"Input file {file} is empty.")
 
-    Args:
-        handle (text file): A handle to a `text file`_ object. The read position is
-        expected to be at the beginning (index 0).
+    try:
+        if extension == 'vcf.gz':
+            file_type = 'compressed_variant'
+        elif extension == 'vcf':
+            file_type = 'variant'
+        elif extension == 'fasta':
+            file_type = 'protein'
+        elif extension in ['tsv', 'GSvar']:
+            # Check if the file is a variant annotation file or a peptide file
+            header_columns = [col.strip() for col in file[0].split('\t')]
 
-    Returns:
-        csv.Dialect: The detected tabular format.
+            required_variant_columns = ['#chr', 'start', 'end']
 
-    .. _text file:
-        https://docs.python.org/3/glossary.html#term-text-file
+            file_type = 'peptide'
 
-    """
-    peek = read_head(handle)
-    handle.seek(0)
-    sniffer = csv.Sniffer()
-    dialect = sniffer.sniff(peek)
-    return dialect
+            if all(col in required_variant_columns for col in header_columns):
+                file_type = 'variant'
+            elif 'sequence' not in header_columns:
+                raise AssertionError("Peptide input file does not contain mandatory column 'sequence'")
 
+        return file_type
+
+    except Exception as e:
+        raise AssertionError(f"Error with checking samplesheet: {e}. Check correct format for input file {file} in documentation.")
 
 def parse_args(argv=None):
     """Define and immediately parse command line arguments."""
@@ -189,16 +197,6 @@ def parse_args(argv=None):
     return parser.parse_args(argv)
 
 
-def print_error(error, context="Line", context_str=""):
-    error_str = "ERROR: Please check samplesheet -> {}".format(error)
-    if context != "" and context_str != "":
-        error_str = "ERROR: Please check samplesheet -> {}\n{}: '{}'".format(
-            error, context.strip(), context_str.strip()
-        )
-    print(error_str)
-    sys.exit(1)
-
-
 def check_allele_nomenclature(allele):
     pattern = re.compile("(^[A-Z][\*][0-9][0-9][:][0-9][0-9])$")
     return pattern.match(allele) is not None
@@ -214,6 +212,7 @@ def make_dir(path):
 
 
 def check_samplesheet(file_in, file_out):
+
     """
     sample,alleles,mhc_class,filename
     GBM_1,A*01:01;A*02:01;B*07:02;B*24:02;C*03:01;C*04:01,I,gbm_1_anno.vcf|gbm_1_peps.tsv|gbm_1_prot.fasta
@@ -238,89 +237,43 @@ def check_samplesheet(file_in, file_out):
     - Variant VCF format => https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/testdata/variants/variants.vcf
     """
 
-    sample_run_dict = {}
-    with open(file_in, "r") as fin:
+    with open(file_in, newline="", ) as samplesheet:
+        reader = csv.reader(samplesheet)
+
         ## Check header
-        COL_NUM = 4
-        HEADER = ["sample", "alleles", "mhc_class", "filename"]
-        header = [x.strip('"') for x in fin.readline().strip().split(",")]
-        valid_classes = "I,II,H-2"
-        valid_class1_loci = ["A*", "B*", "C*", "E*", "G*"]
-        valid_class2_loci = ["DR", "DP", "DQ"]
-        if header[: len(HEADER)] != HEADER:
-            print("ERROR: Please check samplesheet header -> {} != {}".format("\t".join(header), "\t".join(HEADER)))
-            sys.exit(1)
+        valid_header = ["sample", "alleles", "mhc_class", "filename"]
+        header = [x.strip('"') for x in samplesheet.readline().strip().split(",")]
+        if len(header) != 4:
+            raise ValueError(f"Invalid number of header columns! Make sure the samplesheet is properly comma-separated.")
+        elif header != valid_header:
+            raise AssertionError(f"Invalid samplesheet header (valid = {valid_header})!")
 
-        ## Check sample entries
-        for line in fin:
-            lspl = [x.strip('"').replace(" ", "") for x in line.strip().split(",")]
-            ## Check valid number of columns per row
-            if len(lspl) != len(HEADER):
-                print_error(
-                    "Invalid number of columns (valid = {})!".format(len(HEADER)),
-                    "Line",
-                    line,
-                )
-            num_cols = len([x for x in lspl if x])
-            if num_cols != COL_NUM:
-                print_error(
-                    "Invalid number of populated columns (valid = {})!".format(COL_NUM),
-                    "Line",
-                    line,
-                )
+        ## Check samplesheet entries
+        checker = RowChecker()
+        rows = []
+        for i, row in enumerate(reader):
+            checker.validate(row)
+            #here an allele check with mhcgnomes would be suitable
+            row.append(get_file_type(row[3]))
+            rows.append(row)
 
-            ## Check sample name entries
-            sample, alleles, mhcclass, filename = lspl[: len(HEADER)]
+        if len(checker.rows) == 0:
+            raise AssertionError("Samplesheet contains no entries!")
 
-            ## Check given file types
-            if not filename.lower().endswith((".vcf", ".vcf.gz", ".tsv", ".GSvar", ".fasta", ".txt")):
-                print_error("Samplesheet contains unsupported file type!", "Line", line)
-
-            # Check given mhc classes
-            if mhcclass not in valid_classes:
-                print_error("Samplesheet contains unsupported mhc class!", "Line", line)
-
-            # Check mhc class and allele combintion
-            if (
-                not os.path.isfile(alleles)
-                and mhcclass == "I"
-                and any(substring in alleles for substring in valid_class2_loci)
-                or mhcclass == "II"
-                and any(substring in alleles for substring in valid_class1_loci)
-            ):
-                print_error("Samplesheet contains invalid mhc class and allele combination!", "Line", line)
-
-            sample_info = [sample, alleles, mhcclass, filename]
-            ## Create sample mapping dictionary
-            if sample not in sample_run_dict:
-                sample_run_dict[sample] = [sample_info]
-            else:
-                if sample_info in sample_run_dict[sample]:
-                    print_error("Samplesheet contains duplicate rows!", "Line", line)
-                else:
-                    sample_run_dict[sample].append(sample_info)
-
-    ## Write validated samplesheet with appropriate columns
-    if len(sample_run_dict) > 0:
+        ## Write validated samplesheet with appropriate columns
         out_dir = os.path.dirname(file_out)
         make_dir(out_dir)
         with open(file_out, "w") as fout:
-            fout.write(",".join(["sample", "alleles", "mhc_class", "filename"]) + "\n")
-
-            for sample in sorted(sample_run_dict.keys()):
-                for val in sample_run_dict[sample]:
-                    fout.write(",".join(val) + "\n")
-    else:
-        print_error("No entries to process!", context="File", context_str="Samplesheet: {}".format(file_in))
-
+            fout.write(",".join(valid_header) + ",file_type\n")
+            for row in rows:
+                fout.write(",".join(row) + "\n")
 
 def main(argv=None):
     """Coordinate argument parsing and program execution."""
     args = parse_args(argv)
     logging.basicConfig(level=args.log_level, format="[%(levelname)s] %(message)s")
     if not args.file_in.is_file():
-        logger.error(f"The given input file {args.file_in} was not found!")
-        sys.exit(2)
+        raise AssertionError(f"The given input file {args.file_in} does not exist!")
     args.file_out.parent.mkdir(parents=True, exist_ok=True)
     check_samplesheet(args.file_in, args.file_out)
 

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -251,7 +251,6 @@ def check_samplesheet(file_in, file_out):
         ## Check header
         valid_header = ["sample", "alleles", "mhc_class", "filename"]
         header = [x.strip('"') for x in samplesheet.readline().strip().split(",")]
-        print(header)
         if len(header) != 4:
             raise ValueError(
                 f"Invalid number of header columns! Make sure the samplesheet is properly comma-separated."

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -274,7 +274,7 @@ def check_samplesheet(file_in, file_out):
         out_dir = os.path.dirname(file_out)
         make_dir(out_dir)
         with open(file_out, "w") as fout:
-            valid_header.append("file_type")
+            valid_header.append("inputtype")
             fout.write(",".join(valid_header) + "\n")
             for row in rows:
                 fout.write(",".join(row) + "\n")

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -15,6 +15,7 @@ import numpy as np
 import epytope.Core.Generator as generator
 import math
 import json
+import urllib.request
 
 from epytope.IO.MartsAdapter import MartsAdapter
 from epytope.Core.Variant import Variant, VariationType, MutationSyntax
@@ -1335,8 +1336,12 @@ def __main__():
         )
 
     # get the alleles
-    # alleles = FileReader.read_lines(args.alleles, in_type=Allele)
-    alleles = [Allele(a) for a in args.alleles.split(";")]
+    if args.alleles.startswith("http"):
+        alleles = [Allele(a) for a in urllib.request.urlopen(args.alleles).read().decode("utf-8").splitlines()]
+    elif args.alleles.endswith(".txt"):
+        alleles = [Allele(a) for a in open(args.alleles, "r").read().splitlines()]
+    else:
+        alleles = [Allele(a) for a in args.alleles.split(";")]
 
     # initialize MartsAdapter, GRCh37 or GRCh38 based
     ma = MartsAdapter(biomart=references[args.reference])

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -54,12 +54,40 @@ process {
         ext.args = "--tools ${params.tools} --peptides "
     }
 
+        withName: SYFPEITHI{
+        publishDir = [
+            path: { "${params.outdir}/syfpeithi" },
+            mode: params.publish_dir_mode
+        ]
+    }
+
+    withName: MHCFLURRY{
+            publishDir = [
+                path: { "${params.outdir}/mhcflurry" },
+                mode: params.publish_dir_mode
+            ]
+        }
+
+    withName: MHCNUGGETS{
+            publishDir = [
+                path: { "${params.outdir}/mhcnuggets" },
+                mode: params.publish_dir_mode
+            ]
+        }
+
     withName: EPYTOPE_GENERATE_PEPTIDES {
         publishDir = [
             path: { "${params.outdir}/generated_peptides/${meta.sample}" },
             mode: params.publish_dir_mode
         ]
         ext.args = ''
+    }
+
+        withName: NETMHCPAN{
+        publishDir = [
+            path: { "${params.outdir}/netmhcpan" },
+            mode: params.publish_dir_mode
+        ]
     }
 
     withName: SPLIT_PEPTIDES_PEPTIDES {

--- a/modules/local/merge_predictions.nf
+++ b/modules/local/merge_predictions.nf
@@ -1,6 +1,6 @@
 process MERGE_PREDICTIONS {
     label 'process_single'
-    tag "${metadata.sample}"
+    tag "${meta.sample}"
 
     conda "bioconda::mhcgnomes=1.8.4"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
@@ -8,37 +8,16 @@ process MERGE_PREDICTIONS {
         'quay.io/biocontainers/mhcgnomes:1.8.4--pyh7cba7a3_0' }"
 
     input:
-    tuple val(metadata), path(prediction_files), path(metadata_file)
+    tuple val(meta), path(prediction_files), path(metadata_file)
 
     output:
-    tuple val(metadata), path("*.tsv"), emit: merged
+    tuple val(meta), path("*.tsv"), emit: merged
     path "versions.yml", emit: versions
 
     script:
     def output = prediction_files.first().baseName.split("_").dropRight(2).join("_")
-    def min_length = (metadata.mhc_class == "I") ? params.min_peptide_length_mhc_I : params.min_peptide_length_mhc_II
-    def max_length = (metadata.mhc_class == "I") ? params.max_peptide_length_mhc_I : params.max_peptide_length_mhc_II
-
-    def syfpeithi_threshold = params.syfpeithi_threshold ? "--syfpeithi_threshold ${params.syfpeithi_threshold}" : ""
-    def mhcflurry_threshold = params.mhcflurry_threshold ? "--mhcflurry_threshold ${params.mhcflurry_threshold}" : ""
-    def mhcnuggets_threshold = params.mhcnuggets_threshold ? "--mhcnuggets_threshold ${params.mhcnuggets_threshold}" : ""
-    def netmhcpan_threshold = params.netmhcpan_threshold ? "--netmhcpan_threshold ${params.netmhcpan_threshold}" : ""
-    def netmhciipan_threshold = params.netmhciipan_threshold ? "--netmhciipan_threshold ${params.netmhciipan_threshold}" : ""
 
     """
-    merge_binding_predictions.py \
-        --input ${prediction_files} \
-        --input_metadata ${metadata_file} \
-        --output ${output}_merged.tsv \
-        --min_peptide_length ${min_length} \
-        --max_peptide_length ${max_length} \
-        $syfpeithi_threshold \
-        $mhcflurry_threshold \
-        $mhcnuggets_threshold \
-        $netmhcpan_threshold \
-        $netmhciipan_threshold
-
-
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         python \$(python --version | sed 's/Python //g')
@@ -51,4 +30,5 @@ process MERGE_PREDICTIONS {
     touch merged_prediction.tsv
     touch versions.yml
     """
+
 }

--- a/modules/local/merge_predictions.nf
+++ b/modules/local/merge_predictions.nf
@@ -1,0 +1,54 @@
+process MERGE_PREDICTIONS {
+    label 'process_single'
+    tag "${metadata.sample}"
+
+    conda "bioconda::mhcgnomes=1.8.4"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/mhcgnomes:1.8.4--pyh7cba7a3_0' :
+        'quay.io/biocontainers/mhcgnomes:1.8.4--pyh7cba7a3_0' }"
+
+    input:
+    tuple val(metadata), path(prediction_files), path(metadata_file)
+
+    output:
+    tuple val(metadata), path("*.tsv"), emit: merged
+    path "versions.yml", emit: versions
+
+    script:
+    def output = prediction_files.first().baseName.split("_").dropRight(2).join("_")
+    def min_length = (metadata.mhc_class == "I") ? params.min_peptide_length_mhc_I : params.min_peptide_length_mhc_II
+    def max_length = (metadata.mhc_class == "I") ? params.max_peptide_length_mhc_I : params.max_peptide_length_mhc_II
+
+    def syfpeithi_threshold = params.syfpeithi_threshold ? "--syfpeithi_threshold ${params.syfpeithi_threshold}" : ""
+    def mhcflurry_threshold = params.mhcflurry_threshold ? "--mhcflurry_threshold ${params.mhcflurry_threshold}" : ""
+    def mhcnuggets_threshold = params.mhcnuggets_threshold ? "--mhcnuggets_threshold ${params.mhcnuggets_threshold}" : ""
+    def netmhcpan_threshold = params.netmhcpan_threshold ? "--netmhcpan_threshold ${params.netmhcpan_threshold}" : ""
+    def netmhciipan_threshold = params.netmhciipan_threshold ? "--netmhciipan_threshold ${params.netmhciipan_threshold}" : ""
+
+    """
+    merge_binding_predictions.py \
+        --input ${prediction_files} \
+        --input_metadata ${metadata_file} \
+        --output ${output}_merged.tsv \
+        --min_peptide_length ${min_length} \
+        --max_peptide_length ${max_length} \
+        $syfpeithi_threshold \
+        $mhcflurry_threshold \
+        $mhcnuggets_threshold \
+        $netmhcpan_threshold \
+        $netmhciipan_threshold
+
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        python \$(python --version | sed 's/Python //g')
+        mhcgnomes \$(python -c "from mhcgnomes import version; print(version.__version__)"   )
+    END_VERSIONS
+    """
+
+    stub:
+    """
+    touch merged_prediction.tsv
+    touch versions.yml
+    """
+}

--- a/modules/local/mhcflurry.nf
+++ b/modules/local/mhcflurry.nf
@@ -1,6 +1,6 @@
 process MHCFLURRY {
     label 'process_single'
-    tag "${metadata.sample}"
+    tag "${meta.sample}"
 
     conda "bioconda::mhcflurry=2.0.6"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
@@ -8,28 +8,26 @@ process MHCFLURRY {
         'quay.io/biocontainers/mhcflurry:2.0.6--pyh7cba7a3_0' }"
 
     input:
-    tuple val(metadata), path(peptide_file)
+    tuple val(meta), path(peptide_file)
 
     output:
-    tuple val(metadata), path("*.tsv"), emit: predicted
+    tuple val(meta), path("*.tsv"), emit: predicted
     path "versions.yml", emit: versions
 
     script:
 
-    if (metadata.mhc_class == "II") {
-        error("MHCflurry prediction of ${metadata.sample} is not possible with MHC class II!")
+    if (meta.mhc_class == "II") {
+        error("MHCflurry prediction of ${meta.sample} is not possible with MHC class II!")
     }
 
-    def prefix = "${metadata.sample}_${peptide_file.baseName}"
-    def min_length = (metadata.mhc_class == "I") ? params.min_peptide_length_mhc_I : params.min_peptide_length_mhc_II
-    def max_length = (metadata.mhc_class == "I") ? params.max_peptide_length_mhc_I : params.max_peptide_length_mhc_II
+    def prefix = "${meta.sample}_${peptide_file.baseName}"
 
     """
     """
 
     stub:
     """
-    touch ${metadata.sample}_predicted_mhcflurry.tsv
+    touch ${meta.sample}_predicted_mhcflurry.tsv
     touch versions.yml
     """
 }

--- a/modules/local/mhcflurry.nf
+++ b/modules/local/mhcflurry.nf
@@ -1,0 +1,35 @@
+process MHCFLURRY {
+    label 'process_single'
+    tag "${metadata.sample}"
+
+    conda "bioconda::mhcflurry=2.0.6"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/mhcflurry:2.0.6--pyh7cba7a3_0' :
+        'quay.io/biocontainers/mhcflurry:2.0.6--pyh7cba7a3_0' }"
+
+    input:
+    tuple val(metadata), path(peptide_file)
+
+    output:
+    tuple val(metadata), path("*.tsv"), emit: predicted
+    path "versions.yml", emit: versions
+
+    script:
+
+    if (metadata.mhc_class == "II") {
+        error("MHCflurry prediction of ${metadata.sample} is not possible with MHC class II!")
+    }
+
+    def prefix = "${metadata.sample}_${peptide_file.baseName}"
+    def min_length = (metadata.mhc_class == "I") ? params.min_peptide_length_mhc_I : params.min_peptide_length_mhc_II
+    def max_length = (metadata.mhc_class == "I") ? params.max_peptide_length_mhc_I : params.max_peptide_length_mhc_II
+
+    """
+    """
+
+    stub:
+    """
+    touch ${metadata.sample}_predicted_mhcflurry.tsv
+    touch versions.yml
+    """
+}

--- a/modules/local/mhcnuggets.nf
+++ b/modules/local/mhcnuggets.nf
@@ -1,0 +1,29 @@
+process MHCNUGGETS {
+    label 'process_low'
+    tag "${metadata.sample}"
+
+    conda "bioconda::mhcnuggets=2.4.0"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/mhcnuggets:2.4.0--pyh7cba7a3_0' :
+        'quay.io/biocontainers/mhcnuggets:2.4.0--pyh7cba7a3_0' }"
+
+    input:
+    tuple val(metadata), path(peptide_file)
+
+    output:
+    tuple val(metadata), path("*.tsv"), emit: predicted
+    path "versions.yml", emit: versions
+
+    script:
+    def prefix = "${metadata.sample}_${peptide_file.baseName}"
+    def min_length = (metadata.mhc_class == "I") ? params.min_peptide_length_mhc_I : params.min_peptide_length_mhc_II
+    def max_length = (metadata.mhc_class == "I") ? params.max_peptide_length_mhc_I : params.max_peptide_length_mhc_II
+    """
+    """
+
+    stub:
+    """
+    touch ${metadata.sample}_predicted_mhcnuggets.tsv
+    touch versions.yml
+    """
+}

--- a/modules/local/mhcnuggets.nf
+++ b/modules/local/mhcnuggets.nf
@@ -1,29 +1,27 @@
 process MHCNUGGETS {
     label 'process_low'
-    tag "${metadata.sample}"
+    tag "${meta.sample}"
 
-    conda "bioconda::mhcnuggets=2.4.0"
+    conda "bioconda::mhcnuggets=2.4.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mhcnuggets:2.4.0--pyh7cba7a3_0' :
-        'quay.io/biocontainers/mhcnuggets:2.4.0--pyh7cba7a3_0' }"
+        'https://depot.galaxyproject.org/singularity/mhcnuggets:2.4.1--pyh7cba7a3_0' :
+        'quay.io/biocontainers/mhcnuggets:2.4.1--pyh7cba7a3_0' }"
 
     input:
-    tuple val(metadata), path(peptide_file)
+    tuple val(meta), path(peptide_file)
 
     output:
-    tuple val(metadata), path("*.tsv"), emit: predicted
+    tuple val(meta), path("*.tsv"), emit: predicted
     path "versions.yml", emit: versions
 
     script:
-    def prefix = "${metadata.sample}_${peptide_file.baseName}"
-    def min_length = (metadata.mhc_class == "I") ? params.min_peptide_length_mhc_I : params.min_peptide_length_mhc_II
-    def max_length = (metadata.mhc_class == "I") ? params.max_peptide_length_mhc_I : params.max_peptide_length_mhc_II
+    def prefix = "${meta.sample}_${peptide_file.baseName}"
     """
     """
 
     stub:
     """
-    touch ${metadata.sample}_predicted_mhcnuggets.tsv
+    touch ${meta.sample}_predicted_mhcnuggets.tsv
     touch versions.yml
     """
 }

--- a/modules/local/netmhciipan.nf
+++ b/modules/local/netmhciipan.nf
@@ -1,19 +1,19 @@
 process NETMHCIIPAN {
     label 'process_single'
-    tag "${metadata.sample}"
+    tag "${meta.sample}"
 
 
     container 'ghcr.io/jonasscheid/epitopeprediction-2:netmhc'
 
     input:
-    tuple val(metadata), path(peptide_file)
+    tuple val(meta), path(peptide_file)
 
     output:
-    tuple val(metadata), path("*.tsv"), emit: predicted
+    tuple val(meta), path("*.tsv"), emit: predicted
     path "versions.yml", emit: versions
 
     script:
-    if (metadata.mhc_class != "II") {
+    if (meta.mhc_class != "II") {
         error "NETMHCIIPAN only supports MHC class II. Use NETMHCPAN for MHC class I, or adjust the samplesheet accordingly."
     }
 
@@ -22,7 +22,7 @@ process NETMHCIIPAN {
 
     stub:
     """
-    touch ${metadata.sample}_predicted_netmhciipan.tsv
+    touch ${meta.sample}_predicted_netmhciipan.tsv
     touch versions.yml
     """
 }

--- a/modules/local/netmhciipan.nf
+++ b/modules/local/netmhciipan.nf
@@ -1,0 +1,28 @@
+process NETMHCIIPAN {
+    label 'process_single'
+    tag "${metadata.sample}"
+
+
+    container 'ghcr.io/jonasscheid/epitopeprediction-2:netmhc'
+
+    input:
+    tuple val(metadata), path(peptide_file)
+
+    output:
+    tuple val(metadata), path("*.tsv"), emit: predicted
+    path "versions.yml", emit: versions
+
+    script:
+    if (metadata.mhc_class != "II") {
+        error "NETMHCIIPAN only supports MHC class II. Use NETMHCPAN for MHC class I, or adjust the samplesheet accordingly."
+    }
+
+    """
+    """
+
+    stub:
+    """
+    touch ${metadata.sample}_predicted_netmhciipan.tsv
+    touch versions.yml
+    """
+}

--- a/modules/local/netmhcpan.nf
+++ b/modules/local/netmhcpan.nf
@@ -1,18 +1,18 @@
 process NETMHCPAN {
     label 'process_single'
-    tag "${metadata.sample}"
+    tag "${meta.sample}"
 
     container 'ghcr.io/jonasscheid/epitopeprediction-2:netmhc'
 
     input:
-    tuple val(metadata), path(peptide_file), path(nonfree_tools)
+    tuple val(meta), path(peptide_file), path(nonfree_tools)
 
     output:
-    tuple val(metadata), path("*.tsv"), emit: predicted
+    tuple val(meta), path("*.tsv"), emit: predicted
     path "versions.yml", emit: versions
 
     script:
-    if (metadata.mhc_class != "I") {
+    if (meta.mhc_class != "I") {
         error "NETMHCPAN only supports MHC class I. Use NETMHCIIPAN for MHC class II, or adjust the samplesheet accordingly."
     }
     def prefix = peptide_file.baseName
@@ -21,7 +21,7 @@ process NETMHCPAN {
     """
     stub:
     """
-    touch ${metadata.sample}_predicted_netmhcpan.tsv
+    touch ${meta.sample}_predicted_netmhcpan.tsv
     touch versions.yml
     """
 }

--- a/modules/local/netmhcpan.nf
+++ b/modules/local/netmhcpan.nf
@@ -1,0 +1,27 @@
+process NETMHCPAN {
+    label 'process_single'
+    tag "${metadata.sample}"
+
+    container 'ghcr.io/jonasscheid/epitopeprediction-2:netmhc'
+
+    input:
+    tuple val(metadata), path(peptide_file), path(nonfree_tools)
+
+    output:
+    tuple val(metadata), path("*.tsv"), emit: predicted
+    path "versions.yml", emit: versions
+
+    script:
+    if (metadata.mhc_class != "I") {
+        error "NETMHCPAN only supports MHC class I. Use NETMHCIIPAN for MHC class II, or adjust the samplesheet accordingly."
+    }
+    def prefix = peptide_file.baseName
+
+    """
+    """
+    stub:
+    """
+    touch ${metadata.sample}_predicted_netmhcpan.tsv
+    touch versions.yml
+    """
+}

--- a/modules/local/prepare_prediction_input.nf
+++ b/modules/local/prepare_prediction_input.nf
@@ -18,8 +18,8 @@ process PREPARE_PREDICTION_INPUT {
 
     script:
     //TODO handle the thresholds (parse the --tools_thresholds and --use_affinity_thresholds)
-    def min_length = (metadata.mhc_class == "I") ? params.min_peptide_length_mhc_I : params.min_peptide_length_mhc_II
-    def max_length = (metadata.mhc_class == "I") ? params.max_peptide_length_mhc_I : params.max_peptide_length_mhc_II
+    def min_length = (meta.mhc_class == "I") ? params.min_peptide_length_mhc_I : params.min_peptide_length_mhc_II
+    def max_length = (meta.mhc_class == "I") ? params.max_peptide_length_mhc_I : params.max_peptide_length_mhc_II
     //tools über params.tools ziehen
 
     """

--- a/modules/local/prepare_prediction_input.nf
+++ b/modules/local/prepare_prediction_input.nf
@@ -1,0 +1,21 @@
+//and also do the allele name
+
+process PREPARE_PREDICITION_INPUT {
+    label 'process_single'
+    tag "${metadata.sample}"
+
+    input:
+    tuple val(metadata), path(prediction_files), path(metadata_file)
+
+    output:
+    tuple val(metadata), path("*.tsv"), emit: merged
+    path "versions.yml", emit: versions
+
+    script:
+    """
+    """
+
+    stub:
+    """
+    """
+}

--- a/modules/local/prepare_prediction_input.nf
+++ b/modules/local/prepare_prediction_input.nf
@@ -1,21 +1,33 @@
 //and also do the allele name
 
-process PREPARE_PREDICITION_INPUT {
+process PREPARE_PREDICTION_INPUT {
     label 'process_single'
-    tag "${metadata.sample}"
+    tag "${meta.sample}"
+
+    conda "bioconda::mhcgnomes=1.8.4"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/mhcgnomes:1.8.4--pyh7cba7a3_0' :
+        'quay.io/biocontainers/mhcgnomes:1.8.4--pyh7cba7a3_0' }"
 
     input:
-    tuple val(metadata), path(prediction_files), path(metadata_file)
+    tuple val(meta), path(peptide_file)
 
     output:
-    tuple val(metadata), path("*.tsv"), emit: merged
+    tuple val(meta), path("*.csv"), emit: prepared
     path "versions.yml", emit: versions
 
     script:
+    //TODO handle the thresholds (parse the --tools_thresholds and --use_affinity_thresholds)
+    def min_length = (metadata.mhc_class == "I") ? params.min_peptide_length_mhc_I : params.min_peptide_length_mhc_II
+    def max_length = (metadata.mhc_class == "I") ? params.max_peptide_length_mhc_I : params.max_peptide_length_mhc_II
+    //tools über params.tools ziehen
+
     """
     """
 
     stub:
     """
+    touch syfpeithi_input.csv
+    touch versions.yml
     """
 }

--- a/modules/local/syfpeithi.nf
+++ b/modules/local/syfpeithi.nf
@@ -1,0 +1,30 @@
+process SYFPEITHI {
+    label 'process_single'
+    tag "${metadata.sample}"
+
+    conda "bioconda::epytope=3.1.0"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/epytope:3.1.0--pyh5e36f6f_0' :
+        'quay.io/biocontainers/epytope:3.1.0--pyh5e36f6f_0' }"
+
+    input:
+    tuple val(metadata), path(peptide_file)
+
+    output:
+    tuple val(metadata), path("*.tsv"), emit: predicted
+    path "versions.yml", emit: versions
+
+    script:
+    def prefix = "${metadata.sample}_${peptide_file.baseName}"
+    def min_length = (metadata.mhc_class == "I") ? params.min_peptide_length_mhc_I : params.min_peptide_length_mhc_II
+    def max_length = (metadata.mhc_class == "I") ? params.max_peptide_length_mhc_I : params.max_peptide_length_mhc_II
+
+    """
+    """
+
+    stub:
+    """
+    touch ${metadata.sample}_predicted_syfpeithi.tsv
+    touch versions.yml
+    """
+}

--- a/modules/local/syfpeithi.nf
+++ b/modules/local/syfpeithi.nf
@@ -1,6 +1,6 @@
 process SYFPEITHI {
     label 'process_single'
-    tag "${metadata.sample}"
+    tag "${meta.sample}"
 
     conda "bioconda::epytope=3.1.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
@@ -8,23 +8,21 @@ process SYFPEITHI {
         'quay.io/biocontainers/epytope:3.1.0--pyh5e36f6f_0' }"
 
     input:
-    tuple val(metadata), path(peptide_file)
+    tuple val(meta), path(peptide_file)
 
     output:
-    tuple val(metadata), path("*.tsv"), emit: predicted
+    tuple val(meta), path("*.tsv"), emit: predicted
     path "versions.yml", emit: versions
 
     script:
-    def prefix = "${metadata.sample}_${peptide_file.baseName}"
-    def min_length = (metadata.mhc_class == "I") ? params.min_peptide_length_mhc_I : params.min_peptide_length_mhc_II
-    def max_length = (metadata.mhc_class == "I") ? params.max_peptide_length_mhc_I : params.max_peptide_length_mhc_II
-
+    def prefix = "${meta.sample}_${peptide_file.baseName}"
     """
     """
 
     stub:
     """
-    touch ${metadata.sample}_predicted_syfpeithi.tsv
+    touch ${meta.sample}_predicted_syfpeithi.tsv
     touch versions.yml
     """
+
 }

--- a/subworkflows/local/input_check.nf
+++ b/subworkflows/local/input_check.nf
@@ -30,7 +30,7 @@ def get_samplesheet_paths(LinkedHashMap row) {
     meta.sample         = row.sample
     meta.alleles        = row.alleles
     meta.mhcclass       = row.mhc_class
-    meta.file_type      = row.file_type
+    meta.inputtype      = row.inputtype
 
     def array = []
     if (!file(row.filename).exists()) {

--- a/subworkflows/local/input_check.nf
+++ b/subworkflows/local/input_check.nf
@@ -15,7 +15,7 @@ workflow INPUT_CHECK {
         .map { get_samplesheet_paths(it) }
         .set { meta }
 
-    emit: meta                  // channel: [ val(metadata), [ files ] ]
+    emit: meta                  // channel: [ val(meta), [ files ] ]
     versions = SAMPLESHEET_CHECK.out.versions // channel: [ versions.yml ]
 }
 
@@ -26,10 +26,9 @@ def get_samplesheet_paths(LinkedHashMap row) {
     // and return a list of meta and the filename.
     //---------
 
-    def allele_string = generate_allele_string(row.alleles, row.mhc_class)
     def meta = [:]
     meta.sample         = row.sample
-    meta.alleles        = allele_string
+    meta.alleles        = row.alleles
     meta.mhcclass       = row.mhc_class
     meta.file_type      = row.file_type
 

--- a/subworkflows/local/input_check.nf
+++ b/subworkflows/local/input_check.nf
@@ -11,25 +11,27 @@ workflow INPUT_CHECK {
     main:
     SAMPLESHEET_CHECK ( samplesheet )
         .csv
-        .splitCsv ( header:true, sep:',' )
+        .splitCsv ( header:true )
         .map { get_samplesheet_paths(it) }
-        .set { reads }
+        .set { meta }
 
-    emit:
-    reads                                     // channel: [ val(meta), [ reads ] ]
+    emit: meta                  // channel: [ val(metadata), [ files ] ]
     versions = SAMPLESHEET_CHECK.out.versions // channel: [ versions.yml ]
 }
 
 // Function to get list of [ meta, filenames ]
 def get_samplesheet_paths(LinkedHashMap row) {
+    //---------
+    // Save sample, alleles, mhc_class and file_type in a dictionary (metadata)
+    // and return a list of meta and the filename.
+    //---------
 
     def allele_string = generate_allele_string(row.alleles, row.mhc_class)
-    def type = determine_input_type(row.filename)
     def meta = [:]
     meta.sample         = row.sample
     meta.alleles        = allele_string
     meta.mhcclass       = row.mhc_class
-    meta.inputtype      = type
+    meta.file_type      = row.file_type
 
     def array = []
     if (!file(row.filename).exists()) {
@@ -57,29 +59,4 @@ def generate_allele_string(String alleles, String mhcclass) {
         allele_string = alleles
     }
     return allele_string
-}
-
-def determine_input_type(String filename) {
-    def filetype
-    def input_file = file(filename)
-    def extension = input_file.extension
-
-    if (filename.endsWith("vcf.gz") ) {
-        filetype = "variant_compressed"
-    }
-    else if (extension == "vcf") {
-        filetype = "variant"
-    }
-    else if ( extension == "tsv" | extension == "GSvar" ) {
-        // Check if it is a variant annotation file or a peptide file
-        input_file.withReader {
-            def first_header_col = it.readLine().split('\t')[0]
-            if (first_header_col == "id") { filetype = "peptide" }
-            else if (first_header_col == "#chr") {filetype = "variant"}
-        }
-    }
-    else {
-        filetype = "protein"
-    }
-    return filetype
 }

--- a/subworkflows/local/mhc_binding_prediction.nf
+++ b/subworkflows/local/mhc_binding_prediction.nf
@@ -58,7 +58,6 @@ workflow MHC_BINDING_PREDICTION {
 
     //remove the null (it[1]) in the channel output and join metadata and input channel with metadata and output channel
     ch_combined_predictions = ch_combined_predictions.map{ it -> [it[0], it[2..-1]]}.join(metadata_and_file, remainder: true)
-    ch_combined_predictions.view()
 
     //merge the prediction output of all tools into one output merged_prediction.tsv
     MERGE_PREDICTIONS (ch_combined_predictions)

--- a/subworkflows/local/mhc_binding_prediction.nf
+++ b/subworkflows/local/mhc_binding_prediction.nf
@@ -1,0 +1,104 @@
+//
+// Check input samplesheet and get read channels
+//
+
+include { SYFPEITHI } from '../../modules/local/syfpeithi'
+include { MHCFLURRY } from '../../modules/local/mhcflurry'
+include { MHCNUGGETS } from '../../modules/local/mhcnuggets'
+include { NETMHCPAN } from '../../modules/local/netmhcpan'
+include { NETMHCIIPAN } from '../../modules/local/netmhciipan'
+include { EXTERNAL_TOOLS_IMPORT} from '../../modules/local/external_tools_import'
+include { MERGE_PREDICTIONS } from '../../modules/local/merge_predictions'
+
+
+workflow MHC_BINDING_PREDICTION {
+    take:
+        metadata_and_file
+
+    main:
+        ch_versions = Channel.empty()
+        ch_combined_predictions = Channel.empty()
+
+        if (params.tools.isEmpty()) { exit 1, "No valid tools specified." }
+
+        tools = params.tools.split(',')
+
+        if ( "syfpeithi" in tools )
+        {
+        SYFPEITHI ( metadata_and_file )
+        ch_versions = ch_versions.mix(SYFPEITHI.out.versions)
+        ch_combined_predictions = ch_combined_predictions.join(SYFPEITHI.out.predicted, remainder: true)
+        }
+        if ( "mhcflurry" in tools )
+        {
+        MHCFLURRY ( metadata_and_file )
+        ch_versions = ch_versions.mix(MHCFLURRY.out.versions)
+        ch_combined_predictions = ch_combined_predictions.join(MHCFLURRY.out.predicted, remainder: true)
+        }
+        if ( "mhcnuggets" in tools )
+        {
+        MHCNUGGETS ( metadata_and_file )
+        ch_versions = ch_versions.mix(MHCNUGGETS.out.versions)
+        ch_combined_predictions = ch_combined_predictions.join(MHCNUGGETS.out.predicted, remainder: true)
+        }
+        if ( "netmhcpan" in tools )
+        {
+        EXTERNAL_TOOLS_IMPORT (parse_netmhc_params("netmhcpan", "4.1"))
+        NETMHCPAN (metadata_and_file.combine(EXTERNAL_TOOLS_IMPORT.out.nonfree_tools))
+        ch_versions = ch_versions.mix(NETMHCPAN.out.versions)
+        ch_combined_predictions = ch_combined_predictions.join(NETMHCPAN.out.predicted, remainder: true)
+        }
+        if ( "netmhciipan" in tools )
+        {
+        // TODO: External tools import for netmhciipan
+        NETMHCIIPAN (metadata_and_file)
+        ch_versions = ch_versions.mix(NETMHCIIPAN.out.versions)
+        ch_combined_predictions = ch_combined_predictions.join(NETMHCIIPAN.out.predicted, remainder: true)
+        }
+
+    //remove the null (it[1]) in the channel output and join metadata and input channel with metadata and output channel
+    ch_combined_predictions = ch_combined_predictions.map{ it -> [it[0], it[2..-1]]}.join(metadata_and_file, remainder: true)
+    ch_combined_predictions.view()
+
+    //merge the prediction output of all tools into one output merged_prediction.tsv
+    MERGE_PREDICTIONS (ch_combined_predictions)
+
+    ch_versions = ch_versions.mix(MERGE_PREDICTIONS.out.versions)
+
+    emit:
+    predicted = MERGE_PREDICTIONS.out.merged
+    versions = ch_versions
+}
+
+// Functions
+def parse_netmhc_params(tool_name, tool_version) {
+    // Check if the _path parameter was set for this tool
+    if (!params["${tool_name}_path"])
+    {
+        error("--${tool_name}_path not specified, but --tools contains ${tool_name}. Both have to be specified to enable ${tool_name}. Ignoring.")
+    }
+    else if (params["${tool_name}_path"])
+    {
+    // Import mandatory netmhc metadata
+    def jsonSlurper = new groovy.json.JsonSlurper()
+    def external_tools_meta = jsonSlurper.parse(file(params.external_tools_meta, checkIfExists: true))
+    def entry = external_tools_meta[tool_name][tool_version]
+
+    if (params["netmhc_system"] == 'darwin') {
+        entry = external_tools_meta["${tool_name}_darwin"][tool_version]
+    }
+    // If so, add the tool name and user installation path to the external tools import channel
+    ch_nonfree_paths = Channel.empty()
+    ch_nonfree_paths.bind([
+        tool_name,
+        entry.version,
+        entry.software_md5,
+        file(params["${tool_name}_path"], checkIfExists:true),
+        file(entry.data_url),
+        entry.data_md5,
+        entry.binary_name
+    ])
+
+    return ch_nonfree_paths
+    }
+}

--- a/workflows/epitopeprediction.nf
+++ b/workflows/epitopeprediction.nf
@@ -116,13 +116,13 @@ workflow EPITOPEPREDICTION {
     INPUT_CHECK.out.meta
                 .branch {
                     meta_data, input_file ->
-                        variant_compressed : meta_data.file_type == 'variant_compressed'
+                        variant_compressed : meta_data.inputtype == 'variant_compressed'
                             return [ meta_data, input_file ]
-                        variant_uncompressed :  meta_data.file_type == 'variant'
+                        variant_uncompressed :  meta_data.inputtype == 'variant'
                             return [ meta_data, input_file ]
-                        peptide :  meta_data.file_type == 'peptide'
+                        peptide :  meta_data.inputtype == 'peptide'
                             return [ meta_data, input_file ]
-                        protein :  meta_data.file_type == 'protein'
+                        protein :  meta_data.inputtype == 'protein'
                             return [ meta_data, input_file ]
                     }
                 .set { ch_samples_from_sheet }
@@ -143,9 +143,9 @@ workflow EPITOPEPREDICTION {
         .mix(ch_variants_uncompressed)
         .branch {
                 meta_data, input_file ->
-                variant :  meta_data.file_type == 'variant' | meta_data.file_type == 'variant_compressed'
-                peptide :  meta_data.file_type == 'peptide'
-                protein :  meta_data.file_type == 'protein'
+                variant :  meta_data.inputtype == 'variant' | meta_data.inputtype == 'variant_compressed'
+                peptide :  meta_data.inputtype == 'peptide'
+                protein :  meta_data.inputtype == 'protein'
             }
 
     tools = params.tools?.tokenize(',')

--- a/workflows/epitopeprediction.nf
+++ b/workflows/epitopeprediction.nf
@@ -376,7 +376,7 @@ workflow EPITOPEPREDICTION {
     ch_prediction_input = SPLIT_PEPTIDES_PEPTIDES
             .out
             .splitted
-            .combine( ch_prediction_tool_versions )
+            //.combine( ch_prediction_tool_versions )
             .transpose()
 
     MHC_BINDING_PREDICTION(

--- a/workflows/epitopeprediction.nf
+++ b/workflows/epitopeprediction.nf
@@ -113,16 +113,16 @@ workflow EPITOPEPREDICTION {
     // See the documentation https://nextflow-io.github.io/nf-validation/samplesheets/fromSamplesheet/
     // ! There is currently no tooling to help you write a sample sheet schema
 
-    INPUT_CHECK.out.reads
+    INPUT_CHECK.out.meta
                 .branch {
                     meta_data, input_file ->
-                        variant_compressed : meta_data.inputtype == 'variant_compressed'
+                        variant_compressed : meta_data.file_type == 'variant_compressed'
                             return [ meta_data, input_file ]
-                        variant_uncompressed :  meta_data.inputtype == 'variant'
+                        variant_uncompressed :  meta_data.file_type == 'variant'
                             return [ meta_data, input_file ]
-                        peptide :  meta_data.inputtype == 'peptide'
+                        peptide :  meta_data.file_type == 'peptide'
                             return [ meta_data, input_file ]
-                        protein :  meta_data.inputtype == 'protein'
+                        protein :  meta_data.file_type == 'protein'
                             return [ meta_data, input_file ]
                     }
                 .set { ch_samples_from_sheet }
@@ -143,9 +143,9 @@ workflow EPITOPEPREDICTION {
         .mix(ch_variants_uncompressed)
         .branch {
                 meta_data, input_file ->
-                variant :  meta_data.inputtype == 'variant' | meta_data.inputtype == 'variant_compressed'
-                peptide :  meta_data.inputtype == 'peptide'
-                protein :  meta_data.inputtype == 'protein'
+                variant :  meta_data.file_type == 'variant' | meta_data.file_type == 'variant_compressed'
+                peptide :  meta_data.file_type == 'peptide'
+                protein :  meta_data.file_type == 'protein'
             }
 
     tools = params.tools?.tokenize(',')


### PR DESCRIPTION
Update general structure of MHCbinding subworkflow according to this flowchart.
This is just the bare minimum structure without the prediction functionality. 

- We started with the mhc binding subworflow only for the peptide input type and only for the single input type (implementation for all kinds of inputs will follow)
- The nf core modules for the new subworkflow were added, the functionality will be implemented in the py files corresponding to the modules or in the modules itself
- The mhc binding subworkflow as separate workflows
- The pipeline runs through without functionality `--with-stub`
- The threshold handling will happen in the prepare_prediction_input step


![](https://user-images.githubusercontent.com/43858870/255527974-69928053-41ae-426a-9503-b6c818d6cbaa.png)

<!--
# nf-core/epitopeprediction pull request

Many thanks for contributing to nf-core/epitopeprediction!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
