### PR TITLE
Fix external tools import container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed`
 
-- [213](https://github.com/nf-core/epitopeprediction/pull/203) - Rename param `genome_version` to `genome_reference`, add functionality to handle BioMart archive urls
-- [213](https://github.com/nf-core/epitopeprediction/pull/203) - Update to nf-core template `2.10`
-- [203](https://github.com/nf-core/epitopeprediction/pull/203) - Update to nf-core template `2.9`
-- [203](https://github.com/nf-core/epitopeprediction/pull/203) - Update to nf-core template `2.8`
+- [#213](https://github.com/nf-core/epitopeprediction/pull/203) - Rename param `genome_version` to `genome_reference`, add functionality to handle BioMart archive urls
+- [#213](https://github.com/nf-core/epitopeprediction/pull/203) - Update to nf-core template `2.10`
+- [#203](https://github.com/nf-core/epitopeprediction/pull/203) - Update to nf-core template `2.9`
+- [#203](https://github.com/nf-core/epitopeprediction/pull/203) - Update to nf-core template `2.8`
 - [#206](https://github.com/nf-core/epitopeprediction/issues/206) - Update the row checker class.
+
+### `Fixed`
+
+- [#219](https://github.com/nf-core/epitopeprediction/pull/219) - Fix `EXTERNAL_TOOLS_IMPORT`` container registry and bump version
 
 ## v2.2.1 - WaldhaeuserOst Hotfix - 2023-03-16
 

--- a/modules/local/external_tools_import.nf
+++ b/modules/local/external_tools_import.nf
@@ -7,7 +7,7 @@ process EXTERNAL_TOOLS_IMPORT {
     conda "conda-forge::coreutils=9.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img' :
-        'docker.io/biocontainers/biocontainers:v1.2.0_cv1' }"
+        'docker.io/biocontainers/biocontainers:v1.2.0_cv2' }"
 
     input:
     tuple val(toolname), val(toolversion), val(toolchecksum), path(tooltarball), file(datatarball), val(datachecksum), val(toolbinaryname)

--- a/modules/local/external_tools_import.nf
+++ b/modules/local/external_tools_import.nf
@@ -7,7 +7,7 @@ process EXTERNAL_TOOLS_IMPORT {
     conda "conda-forge::coreutils=9.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv1/biocontainers_v1.2.0_cv1.img' :
-        'biocontainers/biocontainers:v1.2.0_cv1' }"
+        'docker.io/biocontainers/biocontainers:v1.2.0_cv1' }"
 
     input:
     tuple val(toolname), val(toolversion), val(toolchecksum), path(tooltarball), file(datatarball), val(datachecksum), val(toolbinaryname)


### PR DESCRIPTION
This PR is a quick fix for small bug that has been introduced with the new template update. `Quay.io` is now the standard container registry, but for `EXTERNAL_TOOLS_IMPORT`  `biocontainers/biocontainers:v1.2.0_cv1` is used. If `docker.io` is specified it takes precedence.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
