### PR TITLE
Add initial mhcflurry module

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -74,7 +74,7 @@ process {
             ]
         }
 
-    withName: NETMHCPAN{
+    withName: NETMHCPAN {
         ext.args = "-BA"
         publishDir = [
             path: { "${params.outdir}/netmhcpan" },
@@ -82,10 +82,17 @@ process {
         ]
     }
 
-    withName: NETMHCIIPAN{
+    withName: NETMHCIIPAN {
         ext.args = "-BA"
         publishDir = [
             path: { "${params.outdir}/netmhciipan" },
+            mode: params.publish_dir_mode
+        ]
+    }
+
+    withName: MERGE_PREDICTIONS {
+        publishDir = [
+            path: { "${params.outdir}/merged_predictions" },
             mode: params.publish_dir_mode
         ]
     }

--- a/modules/local/mhcflurry.nf
+++ b/modules/local/mhcflurry.nf
@@ -2,12 +2,12 @@ process MHCFLURRY {
     label 'process_single'
     tag "${meta.sample}"
 
-    conda "bioconda::mhcflurry=2.1.1"
+    conda "bioconda::mhcflurry=2.1.4"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mhcflurry:2.1.1--pyh7cba7a3_0' :
-        'quay.io/biocontainers/mhcflurry:2.1.1--pyh7cba7a3_0' }"
+        'https://depot.galaxyproject.org/singularity/mhcflurry:2.1.4--pyh7e72e81_1' :
+        'quay.io/biocontainers/mhcflurry:2.1.4--pyh7e72e81_1' }"
 
-    // userEmulation settings when docker is specified
+    // MHCflurry downloads models always to ~/.local/share/mhcflurry
     containerOptions = (workflow.containerEngine == 'docker') ? '-u $(id -u) -e "HOME=${HOME}" -v /etc/passwd:/etc/passwd:ro -v /etc/shadow:/etc/shadow:ro -v /etc/group:/etc/group:ro -v $HOME:$HOME' : ''
 
     input:
@@ -36,7 +36,6 @@ process MHCFLURRY {
         \$(mhcflurry-predict --version)
     END_VERSIONS
     """
-
 
     stub:
     def args   = task.ext.args ?: ''

--- a/modules/local/mhcflurry.nf
+++ b/modules/local/mhcflurry.nf
@@ -2,33 +2,47 @@ process MHCFLURRY {
     label 'process_single'
     tag "${meta.sample}"
 
-    conda "bioconda::mhcflurry=2.0.6"
+    conda "bioconda::mhcflurry=2.1.1"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mhcflurry:2.1.4--pyh7e72e81_0' :
-        'quay.io/biocontainers/mhcflurry:2.1.4--pyh7e72e81_0' }"
+        'https://depot.galaxyproject.org/singularity/mhcflurry:2.1.1--pyh7cba7a3_0' :
+        'quay.io/biocontainers/mhcflurry:2.1.1--pyh7cba7a3_0' }"
+
+    // userEmulation settings when docker is specified
+    containerOptions = (workflow.containerEngine == 'docker') ? '-u $(id -u) -e "HOME=${HOME}" -v /etc/passwd:/etc/passwd:ro -v /etc/shadow:/etc/shadow:ro -v /etc/group:/etc/group:ro -v $HOME:$HOME' : ''
 
     input:
     tuple val(meta), path(peptide_file)
 
     output:
-    tuple val(meta), path("*.tsv"), emit: predicted
+    tuple val(meta), path("*.csv"), emit: predicted
     path "versions.yml", emit: versions
 
     script:
     if (meta.mhc_class == "II") {
         error("MHCflurry prediction of ${meta.sample} is not possible with MHC class II!")
     }
-    def args       = task.ext.args ?: ''
-    def prefix     = task.ext.prefix ?: meta.sample
+    def args   = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: meta.sample
 
     """
+    mhcflurry-downloads fetch models_class1_presentation
+    mhcflurry-predict \\
+        $peptide_file \\
+        --out ${prefix}_predicted_mhcflurry.csv \\
+        $args
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        \$(mhcflurry-predict --version)
+    END_VERSIONS
     """
+
 
     stub:
-    def args       = task.ext.args ?: ''
-    def prefix     = task.ext.prefix ?: meta.sample
+    def args   = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: meta.sample
     """
-    touch ${prefix}_predicted_mhcflurry.tsv
+    touch ${prefix}_predicted_mhcflurry.csv
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -79,18 +79,18 @@
                 },
                 "max_peptide_length_classI": {
                     "type": "integer",
-                    "default": 11,
+                    "default": 14,
                     "description": "Specifies the maximum peptide length.",
                     "help_text": "Specifies the maximum peptide length (not applied when `--peptides` is specified). Default: MHC class I: 11 aa, MHC class II: 16 aa"
                 },
                 "min_peptide_length_classII": {
                     "type": "integer",
-                    "default": 15,
+                    "default": 8,
                     "description": "Specifies the minimum peptide length for MHC class II peptides."
                 },
                 "max_peptide_length_classII": {
                     "type": "integer",
-                    "default": 16,
+                    "default": 25,
                     "description": "Specifies the maximum peptide length for MHC class II peptides."
                 },
                 "tools": {

--- a/subworkflows/local/mhc_binding_prediction.nf
+++ b/subworkflows/local/mhc_binding_prediction.nf
@@ -42,7 +42,7 @@ workflow MHC_BINDING_PREDICTION {
                         return [meta, file]
                     }
             .set{ ch_prediction_input }
-        ch_prediction_input.netmhciipan.view()
+        ch_prediction_input.mhcflurry.view()
         SYFPEITHI ( ch_prediction_input.syfpeithi )
         ch_versions = ch_versions.mix(SYFPEITHI.out.versions)
         ch_binding_predictors_out = ch_binding_predictors_out.mix(SYFPEITHI.out.predicted)


### PR DESCRIPTION
Add initial mhcflurry module #215 #205
- Download functionality is implemented in the module itself and will be only called once. Models are always stored in `~/.local/share/mhcflurry/<release>`. Unfortunately, that cannot be changed
- MHCflurry `presentation_percentile` is used as metric to define a binder ( see [Paper](https://www.cell.com/cell-systems/fulltext/S2405-4712(20)30239-8?dgcid=raven_jbs_etoc_email) ) 
- Newest 2.1.4 version is currently not usable via conda due to [dependency issues](https://github.com/bioconda/bioconda-recipes/pull/52840)
- Check for supported alleles will be implemented in future PRs
- Tests will be implemented in future PRs

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
