### PR TITLE
Re-implement netmhcpan41b test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,29 +108,33 @@ jobs:
         run: |
           nextflow run ${GITHUB_WORKSPACE} -profile ${{ matrix.tests }},docker --outdir ./results
 
-  nonfree:
-    name: Run NetMHC tool family tests
-    if: "${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/epitopeprediction') }}"
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        NXF_VER:
-          - "24.04.2"
-          - "latest-everything"
-    steps:
-      - name: Check out pipeline code
-        uses: actions/checkout@v3
+nonfree:
+  name: Run NetMHC tool family tests
+  if: "${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/epitopeprediction') }}"
+  runs-on: ubuntu-latest
+  strategy:
+    matrix:
+      NXF_VER:
+        - "24.04.2"
+        - "latest-everything"
+  steps:
+    - name: Check out pipeline code
+      uses: actions/checkout@v3
 
-      - name: Install non-free software
-        env:
-          DECRYPT_PASSPHRASE: ${{ secrets.TEST_NETMHC }}
-        run: |
-          curl -L https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/software/netmhcpan41b.tar.gz.gpg | ${GITHUB_WORKSPACE}/bin/decrypt
+    - name: Import GPG private key
+      run: |
+        echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --import
 
-      - name: Install Nextflow
-        uses: nf-core/setup-nextflow@v1
-        with:
-          version: "${{ matrix.NXF_VER }}"
-      - name: Run pipeline with NetMHCpan
-        run: |
-          nextflow run ${GITHUB_WORKSPACE} -profile test_netmhcpan,docker --outdir ./results
+    - name: Install non-free software
+      env:
+        GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      run: |
+        curl -L https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/software/netmhcpan41b.tar.gz.gpg | gpg --batch --yes --passphrase "$GPG_PASSPHRASE" --output ${GITHUB_WORKSPACE}/netMHCpan-4.1b.Linux.tar.gz --decrypt
+    - name: Install Nextflow
+      uses: nf-core/setup-nextflow@v1
+      with:
+        version: "${{ matrix.NXF_VER }}"
+
+    - name: Run pipeline with NetMHCpan
+      run: |
+        nextflow run ${GITHUB_WORKSPACE} -profile test_netmhcpan,docker --outdir ./results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
           DECRYPT_PASSPHRASE: ${{ secrets.TEST_NETMHC }}
         run: |
           mkdir -v non-free
-          curl -L https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/software/non-free-software.tar.gpg | ${GITHUB_WORKSPACE}/bin/decrypt | tar -C non-free -v -x
+          curl -L https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/software/netmhcpan41b.tar.gz.gpg | ${GITHUB_WORKSPACE}/bin/decrypt | tar -C non-free -v -x
 
       - name: Install Nextflow
         uses: nf-core/setup-nextflow@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,33 +108,33 @@ jobs:
         run: |
           nextflow run ${GITHUB_WORKSPACE} -profile ${{ matrix.tests }},docker --outdir ./results
 
-nonfree:
-  name: Run NetMHC tool family tests
-  if: "${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/epitopeprediction') }}"
-  runs-on: ubuntu-latest
-  strategy:
-    matrix:
-      NXF_VER:
-        - "24.04.2"
-        - "latest-everything"
-  steps:
-    - name: Check out pipeline code
-      uses: actions/checkout@v3
-
-    - name: Import GPG private key
-      run: |
-        echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --import
-
-    - name: Install non-free software
-      env:
-        GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-      run: |
-        curl -L https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/software/netmhcpan41b.tar.gz.gpg | gpg --batch --yes --passphrase "$GPG_PASSPHRASE" --output ${GITHUB_WORKSPACE}/netMHCpan-4.1b.Linux.tar.gz --decrypt
-    - name: Install Nextflow
-      uses: nf-core/setup-nextflow@v1
-      with:
-        version: "${{ matrix.NXF_VER }}"
-
-    - name: Run pipeline with NetMHCpan
-      run: |
-        nextflow run ${GITHUB_WORKSPACE} -profile test_netmhcpan,docker --outdir ./results
+  nonfree:
+    name: Run NetMHC tool family tests
+    if: "${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/epitopeprediction') }}"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        NXF_VER:
+          - "24.04.2"
+          - "latest-everything"
+    steps:
+      - name: Check out pipeline code
+        uses: actions/checkout@v3
+  
+      - name: Import GPG private key
+        run: |
+          echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --import
+  
+      - name: Install non-free software
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          curl -L https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/software/netmhcpan41b.tar.gz.gpg | gpg --batch --yes --passphrase "$GPG_PASSPHRASE" --output ${GITHUB_WORKSPACE}/netMHCpan-4.1b.Linux.tar.gz --decrypt
+      - name: Install Nextflow
+        uses: nf-core/setup-nextflow@v1
+        with:
+          version: "${{ matrix.NXF_VER }}"
+  
+      - name: Run pipeline with NetMHCpan
+        run: |
+          nextflow run ${GITHUB_WORKSPACE} -profile test_netmhcpan,docker --outdir ./results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,15 +121,10 @@ jobs:
       - name: Check out pipeline code
         uses: actions/checkout@v3
   
-      - name: Import GPG private key
-        run: |
-          echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --import
-  
       - name: Install non-free software
-        env:
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
-          curl -L https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/software/netmhcpan41b.tar.gz.gpg | gpg --batch --yes --passphrase "$GPG_PASSPHRASE" --output ${GITHUB_WORKSPACE}/netMHCpan-4.1b.Linux.tar.gz --decrypt
+          curl -L https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/software/netmhcpan41b.tar.gz.gpg | gpg --batch --yes --passphrase "${{ secrets.GPG_PASSPHRASE }}" --output ${GITHUB_WORKSPACE}/netMHCpan-4.1b.Linux.tar.gz --decrypt
+  
       - name: Install Nextflow
         uses: nf-core/setup-nextflow@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,16 +120,16 @@ jobs:
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@v3
-  
+
       - name: Install non-free software
         run: |
-          curl -L https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/software/netmhcpan41b.tar.gz.gpg | gpg --batch --yes --passphrase "${{ secrets.GPG_PASSPHRASE }}" --output ${GITHUB_WORKSPACE}/netMHCpan-4.1b.Linux.tar.gz --decrypt
-  
+          curl -L https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/software/netmhcpan41b.tar.gz.gpg | gpg --batch --yes --pinentry-mode=loopback --passphrase "${{ secrets.GPG_PASSPHRASE }}" --output ${GITHUB_WORKSPACE}/netMHCpan-4.1b.Linux.tar.gz --decrypt
+
       - name: Install Nextflow
         uses: nf-core/setup-nextflow@v1
         with:
           version: "${{ matrix.NXF_VER }}"
-  
+
       - name: Run pipeline with NetMHCpan
         run: |
           nextflow run ${GITHUB_WORKSPACE} -profile test_netmhcpan,docker --outdir ./results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,8 @@ jobs:
 
       - name: Install non-free software
         run: |
-          curl -L https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/software/netmhcpan41b.tar.gz.gpg | gpg --batch --yes --pinentry-mode=loopback --passphrase "${{ secrets.GPG_PASSPHRASE }}" --output ${GITHUB_WORKSPACE}/netMHCpan-4.1b.Linux.tar.gz --decrypt
+          curl -L -o netMHCpan-4.1b.Linux.tar.gz.gpg https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/software/netMHCpan-4.1b.Linux.tar.gz.gpg
+          gpg --batch --yes --pinentry-mode=loopback --passphrase "${{ secrets.GPG_PASSPHRASE }}" --output ${GITHUB_WORKSPACE}/netMHCpan-4.1b.Linux.tar.gz --decrypt netMHCpan-4.1b.Linux.tar.gz.gpg
 
       - name: Install Nextflow
         uses: nf-core/setup-nextflow@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
 
   nonfree:
     name: Run NetMHC tool family tests
-    if: ${{ ( github.event_name == 'push' && github.repository == 'nf-core/epitopeprediction' ) || github.event.pull_request.head.repo.full_name == 'nf-core/epitopeprediction' }}
+    if: "${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/epitopeprediction') }}"
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -125,8 +125,7 @@ jobs:
         env:
           DECRYPT_PASSPHRASE: ${{ secrets.TEST_NETMHC }}
         run: |
-          mkdir -v non-free
-          curl -L https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/software/netmhcpan41b.tar.gz.gpg | ${GITHUB_WORKSPACE}/bin/decrypt | tar -C non-free -v -x
+          curl -L https://raw.githubusercontent.com/nf-core/test-datasets/epitopeprediction/software/netmhcpan41b.tar.gz.gpg | ${GITHUB_WORKSPACE}/bin/decrypt
 
       - name: Install Nextflow
         uses: nf-core/setup-nextflow@v1

--- a/bin/decrypt
+++ b/bin/decrypt
@@ -7,4 +7,4 @@ gpg \
     --yes \
     --decrypt \
     --passphrase="$DECRYPT_PASSPHRASE" \
-    --output -
+    --output netMHCpan-4.1b.Linux.tar.gz

--- a/conf/test_netmhcpan.config
+++ b/conf/test_netmhcpan.config
@@ -21,7 +21,7 @@ params {
 
     input  = params.pipelines_testdata_base_path + 'epitopeprediction/testdata/sample_sheets/sample_sheet_peptides.csv'
     tools = 'netmhcpan'
-    netmhcpan_path = './non-free/netmhcpan.tar.gz'
+    netmhcpan_path = './netMHCpan-4.1b.Linux.tar.gz'
     // Reduce number of possible peptide lengths to speed up test
     min_peptide_length_classI = 9
     max_peptide_length_classI = 10


### PR DESCRIPTION
Currently can only test NetMHCpan-4.1b. NetMHCIIpan-4.3 is > 100MB and cannot be compressed <25MB for GH CI tests.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
