### PR TITLE
Add bcftools/stats with multiQC integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v2.4.0dev [date]
+## v3.0.0dev [date]
+
+### `Added`
+-  [#275](https://github.com/nf-core/epitopeprediction/pull/275) - Added bcftools/stats to add MultiQC plots for variant input
 
 ### `Changed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## v3.0.0dev [date]
 
 ### `Added`
--  [#275](https://github.com/nf-core/epitopeprediction/pull/275) - Added bcftools/stats to add MultiQC plots for variant input
+
+- [#275](https://github.com/nf-core/epitopeprediction/pull/275) - Added bcftools/stats to add MultiQC plots for variant input
 
 ### `Changed`
 

--- a/modules.json
+++ b/modules.json
@@ -5,6 +5,11 @@
         "https://github.com/nf-core/modules.git": {
             "modules": {
                 "nf-core": {
+                    "bcftools/stats": {
+                        "branch": "master",
+                        "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",
+                        "installed_by": ["modules"]
+                    },
                     "cat/cat": {
                         "branch": "master",
                         "git_sha": "08108058ea36a63f141c25c4e75f9f872a5b2296",

--- a/modules/nf-core/bcftools/stats/environment.yml
+++ b/modules/nf-core/bcftools/stats/environment.yml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::bcftools=1.20
+  - bioconda::htslib=1.20

--- a/modules/nf-core/bcftools/stats/main.nf
+++ b/modules/nf-core/bcftools/stats/main.nf
@@ -1,0 +1,60 @@
+process BCFTOOLS_STATS {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/bcftools:1.20--h8b25389_0':
+        'biocontainers/bcftools:1.20--h8b25389_0' }"
+
+    input:
+    tuple val(meta),  path(vcf), path(tbi)
+    tuple val(meta2), path(regions)
+    tuple val(meta3), path(targets)
+    tuple val(meta4), path(samples)
+    tuple val(meta5), path(exons)
+    tuple val(meta6), path(fasta)
+
+    output:
+    tuple val(meta), path("*stats.txt"), emit: stats
+    path  "versions.yml"               , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def regions_file = regions ? "--regions-file ${regions}" : ""
+    def targets_file = targets ? "--targets-file ${targets}" : ""
+    def samples_file =  samples ? "--samples-file ${samples}" : ""
+    def reference_fasta = fasta ? "--fasta-ref ${fasta}" : ""
+    def exons_file = exons      ? "--exons ${exons}" : ""
+    """
+    bcftools stats \\
+        $args \\
+        $regions_file \\
+        $targets_file \\
+        $samples_file \\
+        $reference_fasta \\
+        $exons_file \\
+        $vcf > ${prefix}.bcftools_stats.txt
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bcftools: \$(bcftools --version 2>&1 | head -n1 | sed 's/^.*bcftools //; s/ .*\$//')
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+
+    """
+    touch ${prefix}.bcftools_stats.txt
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bcftools: \$(bcftools --version 2>&1 | head -n1 | sed 's/^.*bcftools //; s/ .*\$//')
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/bcftools/stats/meta.yml
+++ b/modules/nf-core/bcftools/stats/meta.yml
@@ -1,0 +1,105 @@
+name: bcftools_stats
+description: Generates stats from VCF files
+keywords:
+  - variant calling
+  - stats
+  - VCF
+tools:
+  - stats:
+      description: |
+        Parses VCF or BCF and produces text file stats which is suitable for
+        machine processing and can be plotted using plot-vcfstats.
+      homepage: http://samtools.github.io/bcftools/bcftools.html
+      documentation: http://www.htslib.org/doc/bcftools.html
+      doi: 10.1093/bioinformatics/btp352
+      licence: ["MIT"]
+      identifier: biotools:bcftools
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - vcf:
+        type: file
+        description: VCF input file
+        pattern: "*.{vcf}"
+    - tbi:
+        type: file
+        description: |
+          The tab index for the VCF file to be inspected. Optional: only required when parameter regions is chosen.
+        pattern: "*.tbi"
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - regions:
+        type: file
+        description: |
+          Optionally, restrict the operation to regions listed in this file. (VCF, BED or tab-delimited)
+  - - meta3:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - targets:
+        type: file
+        description: |
+          Optionally, restrict the operation to regions listed in this file (doesn't rely upon tbi index files)
+  - - meta4:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - samples:
+        type: file
+        description: |
+          Optional, file of sample names to be included or excluded.
+          e.g. 'file.tsv'
+  - - meta5:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - exons:
+        type: file
+        description: |
+          Tab-delimited file with exons for indel frameshifts (chr,beg,end; 1-based, inclusive, optionally bgzip compressed).
+          e.g. 'exons.tsv.gz'
+  - - meta6:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - fasta:
+        type: file
+        description: |
+          Faidx indexed reference sequence file to determine INDEL context.
+          e.g. 'reference.fa'
+output:
+  - stats:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*stats.txt":
+          type: file
+          description: Text output file containing stats
+          pattern: "*_{stats.txt}"
+  - versions:
+      - versions.yml:
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
+authors:
+  - "@joseespinosa"
+  - "@drpatelh"
+  - "@SusiJo"
+  - "@TCLamnidis"
+maintainers:
+  - "@joseespinosa"
+  - "@drpatelh"
+  - "@SusiJo"
+  - "@TCLamnidis"

--- a/modules/nf-core/bcftools/stats/tests/main.nf.test
+++ b/modules/nf-core/bcftools/stats/tests/main.nf.test
@@ -1,0 +1,182 @@
+nextflow_process {
+
+    name "Test Process BCFTOOLS_STATS"
+    script "../main.nf"
+    process "BCFTOOLS_STATS"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "bcftools"
+    tag "bcftools/stats"
+
+    test("sarscov2 - vcf_gz") {
+
+        when {
+            process {
+                """
+                input[0] = [ [ id:'test' ], // meta map
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                            []]
+                input[1] = [ [], [] ]
+                input[2] = [ [], [] ]
+                input[3] = [ [], [] ]
+                input[4] = [ [], [] ]
+                input[5] = [ [], [] ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.versions).match("versions") },
+                { assert snapshot(file(process.out.stats.get(0).get(1)).readLines()[0..5]).match() },
+            )
+        }
+
+    }
+
+    test("sarscov2 - vcf_gz - regions") {
+
+        when {
+            process {
+                """
+                input[0] = [ [ id:'regions_test' ], // meta map
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz.tbi', checkIfExists: true)]
+                input[1] = [ [id:'regions_test'],
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test3.vcf.gz', checkIfExists: true) ]
+                input[2] = [ [], [] ]
+                input[3] = [ [], [] ]
+                input[4] = [ [], [] ]
+                input[5] = [ [], [] ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.versions).match("regions_versions") },
+                { assert snapshot(file(process.out.stats.get(0).get(1)).readLines()[0..5]).match() },
+            )
+        }
+
+    }
+
+    test("sarscov2 - vcf_gz - targets") {
+
+        when {
+            process {
+                """
+                input[0] = [ [ id:'targets_test' ], // meta map
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                            [] ]
+                input[1] = [ [], [] ]
+                input[2] = [ [id:'targets_test'],
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test2.targets.tsv.gz', checkIfExists: true)
+                            ]
+                input[3] = [ [], [] ]
+                input[4] = [ [], [] ]
+                input[5] = [ [], [] ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.versions).match("targets_versions") },
+                { assert snapshot(file(process.out.stats.get(0).get(1)).readLines()[0..5]).match() },
+            )
+        }
+
+    }
+
+    test("sarscov2 - vcf_gz - exons") {
+
+        when {
+            process {
+                """
+                input[0] = [ [ id:'exon_test' ], // meta map
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                            [] ]
+                input[1] = [ [], [] ]
+                input[2] = [ [], [] ]
+                input[3] = [ [], [] ]
+                input[4] = [ [id: "exon_test"],
+                            file(params.modules_testdata_base_path + 'delete_me/bcftools/stats/exons.tsv.gz', checkIfExists: true) ]
+                input[5] = [ [], [] ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.versions).match("exon_versions") },
+                { assert snapshot(file(process.out.stats.get(0).get(1)).readLines()[0..5]).match() },
+            )
+        }
+
+    }
+
+    test("sarscov2 - vcf_gz - reference") {
+
+        when {
+            process {
+                """
+                input[0] = [ [ id:'ref_test' ], // meta map
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                            [] ]
+                input[1] = [ [], [] ]
+                input[2] = [ [], [] ]
+                input[3] = [ [], [] ]
+                input[4] = [ [], [] ]
+                input[5] = [ [id: 'ref_test'],
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                            ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.versions).match("ref_versions") },
+                { assert snapshot(file(process.out.stats.get(0).get(1)).readLines()[0..5]).match() },
+            )
+        }
+
+    }
+
+
+    test("sarscov2 - vcf_gz - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [ [ id:'test' ], // meta map
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/vcf/test.vcf.gz', checkIfExists: true),
+                            []]
+                input[1] = [ [], [] ]
+                input[2] = [ [], [] ]
+                input[3] = [ [], [] ]
+                input[4] = [ [], [] ]
+                input[5] = [ [], [] ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/bcftools/stats/tests/main.nf.test.snap
+++ b/modules/nf-core/bcftools/stats/tests/main.nf.test.snap
@@ -1,0 +1,180 @@
+{
+    "sarscov2 - vcf_gz - reference": {
+        "content": [
+            [
+                "# This file was produced by bcftools stats (1.20+htslib-1.20) and can be plotted using plot-vcfstats.",
+                "# The command line was:\tbcftools stats  --fasta-ref genome.fasta test.vcf.gz",
+                "#",
+                "# Definition of sets:",
+                "# ID\t[2]id\t[3]tab-separated file names",
+                "ID\t0\ttest.vcf.gz"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-31T18:14:35.506777837"
+    },
+    "sarscov2 - vcf_gz - exons": {
+        "content": [
+            [
+                "# This file was produced by bcftools stats (1.20+htslib-1.20) and can be plotted using plot-vcfstats.",
+                "# The command line was:\tbcftools stats  --exons exons.tsv.gz test.vcf.gz",
+                "#",
+                "# Definition of sets:",
+                "# ID\t[2]id\t[3]tab-separated file names",
+                "ID\t0\ttest.vcf.gz"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-31T18:14:30.57486244"
+    },
+    "versions": {
+        "content": [
+            [
+                "versions.yml:md5,17cdf9d1ad31f6b1f5935dfcc9fe7b9a"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-31T18:16:27.637515559"
+    },
+    "sarscov2 - vcf_gz - targets": {
+        "content": [
+            [
+                "# This file was produced by bcftools stats (1.20+htslib-1.20) and can be plotted using plot-vcfstats.",
+                "# The command line was:\tbcftools stats  --targets-file test2.targets.tsv.gz test.vcf.gz",
+                "#",
+                "# Definition of sets:",
+                "# ID\t[2]id\t[3]tab-separated file names",
+                "ID\t0\ttest.vcf.gz"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-31T18:14:25.732997442"
+    },
+    "regions_versions": {
+        "content": [
+            [
+                "versions.yml:md5,17cdf9d1ad31f6b1f5935dfcc9fe7b9a"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-31T18:16:32.559884458"
+    },
+    "targets_versions": {
+        "content": [
+            [
+                "versions.yml:md5,17cdf9d1ad31f6b1f5935dfcc9fe7b9a"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-31T18:16:37.512009805"
+    },
+    "sarscov2 - vcf_gz - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bcftools_stats.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,17cdf9d1ad31f6b1f5935dfcc9fe7b9a"
+                ],
+                "stats": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bcftools_stats.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,17cdf9d1ad31f6b1f5935dfcc9fe7b9a"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.2"
+        },
+        "timestamp": "2024-06-03T11:57:09.614976125"
+    },
+    "exon_versions": {
+        "content": [
+            [
+                "versions.yml:md5,17cdf9d1ad31f6b1f5935dfcc9fe7b9a"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-31T18:16:42.347397266"
+    },
+    "ref_versions": {
+        "content": [
+            [
+                "versions.yml:md5,17cdf9d1ad31f6b1f5935dfcc9fe7b9a"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-31T18:16:47.26823622"
+    },
+    "sarscov2 - vcf_gz": {
+        "content": [
+            [
+                "# This file was produced by bcftools stats (1.20+htslib-1.20) and can be plotted using plot-vcfstats.",
+                "# The command line was:\tbcftools stats  test.vcf.gz",
+                "#",
+                "# Definition of sets:",
+                "# ID\t[2]id\t[3]tab-separated file names",
+                "ID\t0\ttest.vcf.gz"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-31T18:16:27.670416598"
+    },
+    "sarscov2 - vcf_gz - regions": {
+        "content": [
+            [
+                "# This file was produced by bcftools stats (1.20+htslib-1.20) and can be plotted using plot-vcfstats.",
+                "# The command line was:\tbcftools stats  --regions-file test3.vcf.gz test.vcf.gz",
+                "#",
+                "# Definition of sets:",
+                "# ID\t[2]id\t[3]tab-separated file names",
+                "ID\t0\ttest.vcf.gz"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "23.10.1"
+        },
+        "timestamp": "2024-05-31T18:14:20.759094062"
+    }
+}

--- a/modules/nf-core/bcftools/stats/tests/tags.yml
+++ b/modules/nf-core/bcftools/stats/tests/tags.yml
@@ -1,0 +1,2 @@
+bcftools/stats:
+  - "modules/nf-core/bcftools/stats/**"

--- a/workflows/epitopeprediction.nf
+++ b/workflows/epitopeprediction.nf
@@ -25,11 +25,12 @@ include { MHC_BINDING_PREDICTION } from '../subworkflows/local/mhc_binding_predi
 //
 // MODULE: Installed directly from nf-core/modules
 //
-include { MULTIQC                     } from '../modules/nf-core/multiqc'
 include { GUNZIP as GUNZIP_VCF        } from '../modules/nf-core/gunzip'
+include { BCFTOOLS_STATS              } from '../modules/nf-core/bcftools/stats'
 include { SNPSIFT_SPLIT               } from '../modules/nf-core/snpsift/split'
 include { CAT_CAT as CAT_FASTA        } from '../modules/nf-core/cat/cat/main'
 include { CSVTK_CONCAT                } from '../modules/nf-core/csvtk/concat'
+include { MULTIQC                     } from '../modules/nf-core/multiqc'
 include { paramsSummaryMap            } from 'plugin/nf-schema'
 include { paramsSummaryMultiqc        } from '../subworkflows/nf-core/utils_nfcore_pipeline'
 include { softwareVersionsToYAML      } from '../subworkflows/nf-core/utils_nfcore_pipeline'
@@ -76,6 +77,11 @@ workflow EPITOPEPREDICTION {
     ch_versions = ch_versions.mix(GUNZIP_VCF.out.versions)
 
     ch_variants_uncompressed = GUNZIP_VCF.out.gunzip.mix( ch_samplesheet.variant_uncompressed )
+
+    // Generate Variant Stats for QC report
+    BCFTOOLS_STATS(ch_variants_uncompressed.map{ meta, vcf -> [ meta, vcf, [] ] }, [[:],[]], [[:],[]], [[:],[]], [[:],[]], [[:],[]])
+    ch_versions = ch_versions.mix(BCFTOOLS_STATS.out.versions)
+    ch_multiqc_files = ch_multiqc_files.mix(BCFTOOLS_STATS.out.stats.collect{ meta, stats -> stats })
 
     // (re)combine different input file types
     ch_samples_uncompressed = ch_samplesheet.protein

--- a/workflows/epitopeprediction.nf
+++ b/workflows/epitopeprediction.nf
@@ -79,7 +79,9 @@ workflow EPITOPEPREDICTION {
     ch_variants_uncompressed = GUNZIP_VCF.out.gunzip.mix( ch_samplesheet.variant_uncompressed )
 
     // Generate Variant Stats for QC report
-    BCFTOOLS_STATS(ch_variants_uncompressed.map{ meta, vcf -> [ meta, vcf, [] ] }, [[:],[]], [[:],[]], [[:],[]], [[:],[]], [[:],[]])
+    BCFTOOLS_STATS(
+        ch_variants_uncompressed
+                .map{ meta, vcf -> [ meta, vcf, [] ] }, [[:],[]], [[:],[]], [[:],[]], [[:],[]], [[:],[]])
     ch_versions = ch_versions.mix(BCFTOOLS_STATS.out.versions)
     ch_multiqc_files = ch_multiqc_files.mix(BCFTOOLS_STATS.out.stats.collect{ meta, stats -> stats })
 


### PR DESCRIPTION
Added BCFTOOLS_STATS, which adds nice statistics for variant input #267

<img width="1117" alt="Screenshot 2025-03-26 at 15 00 31" src="https://github.com/user-attachments/assets/6ff9faac-a08a-4948-aa54-c7a3d9310be6" />

## PR checklist



- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
