### PR TITLE
allow relative paths in samplesheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#247](https://github.com/nf-core/epitopeprediction/pull/247) - Update to nf-core template `3.0.2`
 - [#255](https://github.com/nf-core/epitopeprediction/pull/256) - Update to nf-core template `3.1.2`
 
+### `Fixed`
+
+- [#278](https://github.com/nf-core/epitopeprediction/pull/278) - Fixed an issue where relative paths were not properly staged
+
 ## v2.3.1 - Oesterberg - 2024-05-17
 
 ### `Changed`

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -26,6 +26,7 @@
             },
             "filename": {
                 "type": "string",
+                "format": "file-path",
                 "pattern": "^\\S+\\.(vcf|vcf.gz|tsv|fasta|fa)$",
                 "errorMessage": "Variants/proteins/peptides of a sample must be provided and have one of the following extensions: '.vcf', '.vcf.gz', '.tsv', '.fasta', '.fa'",
                 "exists": true

--- a/workflows/epitopeprediction.nf
+++ b/workflows/epitopeprediction.nf
@@ -59,16 +59,17 @@ workflow EPITOPEPREDICTION {
 
     // Load samplesheet and branch channels based on input type
     samplesheet
-        .branch { meta, filename ->
+        .branch { meta, file ->
+            def filename = file.name
             // TODO: Replace sample with id
             variant_compressed : filename.endsWith('.vcf.gz')
-                return [meta + [input_type:'variant_compressed'], filename ]
+                return [meta + [input_type:'variant_compressed'], file ]
             variant_uncompressed : filename.endsWith('.vcf')
-                return [meta + [input_type:'variant'], filename ]
+                return [meta + [input_type:'variant'], file ]
             peptide : filename.endsWith('.tsv')
-                return [meta + [input_type:'peptide'], filename ]
+                return [meta + [input_type:'peptide'], file ]
             protein : filename.endsWith('.fasta') || filename.endsWith('.fa')
-                return [meta + [input_type:'protein'], filename ]
+                return [meta + [input_type:'protein'], file ]
         }
         .set { ch_samplesheet }
 


### PR DESCRIPTION
fixing bug with relative paths not being usable

<!--
# nf-core/epitopeprediction pull request

Many thanks for contributing to nf-core/epitopeprediction!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
