### PR TITLE
Fixes for output file generation

### DIFF
--- a/bin/summarize_results.py
+++ b/bin/summarize_results.py
@@ -199,7 +199,7 @@ class Utils:
                 .apply(lambda row: ','.join(sorted({a for a in row if pd.notna(a)})), axis=1)
         )
 
-        # Add a binder column to the summary (True if best predictor is a binder)
+        # Add a binder column to the summary (True if best predicted allele is a binder)
         summary_df['binder'] = best['binder'].values
 
         return summary_df.reset_index()

--- a/bin/summarize_results.py
+++ b/bin/summarize_results.py
@@ -179,7 +179,7 @@ class Utils:
             .groupby(['predictor', peptide_col], group_keys=False)
             .apply(_pick_best)
         )
-        
+
 
         # now build summary
         summary_df = pd.DataFrame(index=best[peptide_col].unique())
@@ -198,10 +198,10 @@ class Utils:
             summary_df[allele_cols]
                 .apply(lambda row: ','.join(sorted({a for a in row if pd.notna(a)})), axis=1)
         )
-        
+
         # Add a binder column to the summary (True if best predictor is a binder)
         summary_df['binder'] = best['binder'].values
-        
+
         return summary_df.reset_index()
 
     def long2wide(df: pd.DataFrame, peptide_col: str) -> pd.DataFrame:
@@ -218,7 +218,6 @@ class Utils:
         """
         # Identify non-predictor columns to keep as index
         meta_columns = [col for col in df.columns if not any([x in col for x in ['predictor', 'allele', 'BA', 'rank', 'binder']])]
-        
 
         # Pivot to wide format
         df_pivot = df.pivot_table(

--- a/bin/summarize_results.py
+++ b/bin/summarize_results.py
@@ -198,9 +198,9 @@ class Utils:
             summary_df[allele_cols]
                 .apply(lambda row: ','.join(sorted({a for a in row if pd.notna(a)})), axis=1)
         )
-
-        # determine if there is at least one binder
-        summary_df['binder'] = best.filter(regex='_binder$').any(axis=1).values
+        
+        # Add a binder column to the summary (True if best predictor is a binder)
+        summary_df['binder'] = best['binder'].values
         
         return summary_df.reset_index()
 


### PR DESCRIPTION
This PR addresses two issues:

- error in wide table generation due to incorrect meta data column selection
- binder column would always be False

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
