### PR TITLE
Fasta output rework

### DIFF
--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -592,7 +592,7 @@ def write_empty_files(args: argparse.Namespace):
     if args.fasta_output:
         open(f"{args.prefix}.fasta", "w").close()
 
-def generate_fasta_output(output_filename, mutated_proteins, mutated_peptides_df, flanking_region_size: int = 25):
+def generate_fasta_output(output_filename: str, mutated_proteins: list, mutated_peptides_df: pd.DataFrame, flanking_region_size: int):
     """
     Generates a FASTA file from mutated protein sequences,
     integrating additional peptide information from a DataFrame.

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -49,6 +49,7 @@ def parse_args():
     parser.add_argument("-i", "--input", help="SnpEff or VEP annotated variants in VCF format", type=str, required=True)
     parser.add_argument("-p", "--prefix", help="Prefix of output files", type=str, required=True)
     parser.add_argument("--fasta_output", help="Create FASTA file with protein sequences", default=False, action="store_true")
+    parser.add_argument("--flanking_region_size", help="Size of flanking region around mutated peptides in FASTA output", type=int, default=25)
     parser.add_argument("--min_length", help="Minimum peptide length of mutated peptides", type=int, default=8)
     parser.add_argument("--max_length", help="Maximum peptide length of mutated peptides", type=int, default=14)
     parser.add_argument("--genome_reference", help="Reference, retrieved information will be based on this ensembl version", default="https://grch37.ensembl.org/")
@@ -591,6 +592,194 @@ def write_empty_files(args: argparse.Namespace):
     if args.fasta_output:
         open(f"{args.prefix}.fasta", "w").close()
 
+def generate_fasta_output(output_filename, mutated_proteins, mutated_peptides_df, flanking_region_size: int = 25):
+    """
+    Generates a FASTA file from mutated protein sequences,
+    integrating additional peptide information from a DataFrame.
+
+    Args:
+        output_filename (str): The output FASTA file name.
+        mutated_proteins (list): A list of protein objects.
+        mutated_peptides_df (pd.DataFrame): A DataFrame containing peptide-related information such as accessions.
+        flanking_region_size (int): The size of the flanking region added on each side of the mutation.
+    """
+
+    # The final FASTA sequences (wt and one or more mutations per transcript)
+    fasta_dict = {}
+
+    # Temporarily store mutations to be processed later with peptide data
+    temp_mutations_by_transcript = {}
+
+    for p in mutated_proteins:
+        transcript_id = p.transcript_id.split(":")[0]
+        # Catch Wildtypes
+        if len(p.vars) == 0:
+            # The wildtype sequence is stored directly in fasta_dict since it is not modified further
+            fasta_dict.setdefault(transcript_id, {"seq_wt": str(p), "mutations": []})
+        # Mutations with only one variant
+        elif len(p.vars) == 1:
+            # Extract relevant mutation details
+            variant_detail = next(iter(p.vars.values()))[0]
+            cds_mutation_syntax = next(iter(variant_detail.coding.values())).cdsMutationSyntax
+            # Construct the mutation entry
+            mut_entry = {
+                "seq": str(p),
+                "variant_details_gene": cds_mutation_syntax
+            }
+            # Add to list of mutations for this transcript
+            temp_mutations_by_transcript.setdefault(transcript_id, []).append(mut_entry)
+        elif len(p.vars) > 1:
+            # Extract mutation syntax for all variants in the protein
+            mutation_syntax_list = []
+            for var_details in p.vars.values():
+                for variant_detail in var_details:
+                    for coding_variant in variant_detail.coding.values():
+                        cds_mutation_syntax = coding_variant.cdsMutationSyntax
+                        mutation_syntax_list.append(cds_mutation_syntax)
+            # Helper function to extract the first integer position from a mutation syntax string
+            def extract_first_position(s):
+                match = re.search(r"\d+", s)
+                return int(match.group()) if match else None
+
+            # Extract the position numbers from each mutation syntax
+            positions = []
+            for cds_mutation_syntax in mutation_syntax_list:
+                pos = extract_first_position(cds_mutation_syntax)
+                if pos is not None:
+                    positions.append(pos)
+            # Sort mutation_syntax list based on positions
+            mutation_syntax_list = sorted(
+                mutation_syntax_list,
+                key=lambda x: extract_first_position(x) if extract_first_position(x) is not None else float('inf')
+            )
+            # If no positions were found, skip this protein
+            if not positions:
+                logger.warning(f"No valid mutation positions found for transcript {transcript_id} with mutations: {mutation_syntax_list}. Skipping this mutation.")
+                continue
+            # Convert to amino acid positions by dividing by 3
+            positions = sorted(set([pos // 3 for pos in positions]))
+
+            # Check if all of them are within the two flanking regions
+            valid = True
+            for i in positions:
+                for j in positions:
+                    if i != j and abs(i - j) > flanking_region_size * 2:
+                        valid = False
+                        break
+            if valid:
+                # Construct the mutation entry
+                mut_entry = {
+                    "seq": str(p), # Store the full mutated sequence for now
+                    "variant_details_gene": ",".join(mutation_syntax_list)
+                }
+                # Add to list of mutations for this transcript
+                temp_mutations_by_transcript.setdefault(transcript_id, []).append(mut_entry)
+
+    # Drop duplicates in mutated peptides DataFrame and group by transcripts
+    peptides_df_for_lookup = mutated_peptides_df.iloc[:, 1:-1].drop_duplicates()
+    grouped_peptides_df = peptides_df_for_lookup.groupby("transcripts")
+
+    # Collect transcript which are not in the peptide DataFrame or have no unique peptides
+    transcripts_to_remove = set()
+
+    for transcript_id, muts_list in temp_mutations_by_transcript.items():
+        # Check if any peptide data exists for this transcript at all
+        if transcript_id not in grouped_peptides_df.groups:
+            logger.warning(f"No peptide data found for transcript {transcript_id}. Sequences derived from this transcript will be removed from fasta output.")
+            transcripts_to_remove.add(transcript_id)
+            continue
+
+        # Get the subset of the DataFrame relevant to this transcript
+        peptides_for_transcript = grouped_peptides_df.get_group(transcript_id)
+
+        processed_mutations_for_transcript = []
+        for mut in muts_list:
+            # Filter the DataFrame with a regex that matches any of the variant details
+            pattern = "|".join(re.escape(variant_detail) for variant_detail in mut["variant_details_gene"].split(","))
+            filtered_peptides = peptides_for_transcript[
+                peptides_for_transcript["variant_details_gene"].str.contains(pattern, na=False)
+            ]
+            # There should be exactly one matching peptide for each mutation
+            if len(filtered_peptides) == 0:
+                logger.warning(f"No peptides found for transcript {transcript_id} with mutation {mut['variant_details_gene']}. This mutation will be removed from fasta output.")
+                continue
+
+            # Fill fasta dict with metadata (Uniprot, Ensembl IDs)
+            # Assumed to be the same for all mutations of a transcript
+
+            # Small function to join unique values from a Series or DataFrame
+            def unique_join(obj):
+                if isinstance(obj, pd.Series):
+                    return ",".join(sorted(set(obj.astype(str))))
+                elif isinstance(obj, pd.DataFrame):
+                    return ",".join(sorted(set(obj.astype(str).values.flatten())))
+                else:
+                    return str(obj)
+
+            fasta_dict[transcript_id]["uniprot"] = unique_join(filtered_peptides["uniprot"])
+            fasta_dict[transcript_id]["ensembl_gene"] = unique_join(filtered_peptides["gene"])
+            fasta_dict[transcript_id]["ensembl_protein"] = unique_join(filtered_peptides["proteins"])
+            mut["variant_details_protein"] = unique_join(filtered_peptides["variant_details_protein"])
+
+            # +/- flanking region of set number of amino acids around the mutation positions
+            # mut["variant_details_protein"] could contain one or multiple positions, if multiple, get the lowest and highest number
+            positions = [int(m.group()) for m in re.finditer(r"\d+", mut["variant_details_protein"])]
+            if positions:
+                start = max(0, min(positions) - flanking_region_size)
+                end = min(len(mut["seq"]), max(positions) + flanking_region_size)
+                mut["start"] = start
+                mut["end"] = end
+                mut["seq"] = mut["seq"][start:end]
+            else:
+                logger.warning(f"Could not extract position from variant_details_protein: {mut['variant_details_protein']} for transcript {transcript_id}. Skipping sequence slicing for this mutation.")
+                transcripts_to_remove.add(transcript_id)
+                continue
+            
+            processed_mutations_for_transcript.append(mut)
+        
+        # Add list of processed mutations back to the fasta_dict
+        fasta_dict[transcript_id]["mutations"] = processed_mutations_for_transcript
+
+    # Remove any problematic transcripts
+    for k in transcripts_to_remove:
+        if k in fasta_dict:
+            del fasta_dict[k]
+    
+    # Write the FASTA file
+    try:
+        with open(output_filename, "w") as protein_outfile:
+            for k in fasta_dict.keys():
+                transcript_entry = fasta_dict[k]
+
+                # --- Final validation before writing ---
+                # Skip if no wildtype sequence and no mutations were successfully processed for this entry
+                if not transcript_entry["seq_wt"] and not transcript_entry["mutations"]:
+                    continue
+
+                # Ensure essential metadata is present for header creation
+                required_meta_fields = ["uniprot", "ensembl_gene", "ensembl_protein"]
+                if not all(field in transcript_entry for field in required_meta_fields):
+                    logger.warning(f"Missing essential metadata for transcript {k}. Skipping FASTA output for this entry.")
+                    continue
+
+                # Construct common header parts
+                header_start = f">sp|{transcript_entry['uniprot']}"
+                header_middle = f"{transcript_entry['ensembl_gene']}|{k}|{transcript_entry['ensembl_protein']}|{transcript_entry['uniprot']}"
+                
+                # Write the wildtype sequence if available
+                if transcript_entry["seq_wt"]:
+                    protein_outfile.write(f"{header_start}_wt|{header_middle}\n")
+                    protein_outfile.write(f"{transcript_entry['seq_wt']}\n")
+                
+                # Write the mutated sequences
+                for i, mut in enumerate(transcript_entry["mutations"]):
+                    protein_outfile.write(f"{header_start}_mut_{i+1}|{header_middle}|{mut['variant_details_gene']}|{mut['variant_details_protein']}\n")
+                    protein_outfile.write(f"{mut['seq']}\n")
+        logger.info(f"FASTA file successfully generated: {output_filename}")
+    except IOError as e:
+        logger.error(f"Error writing FASTA file {output_filename}: {e}")
+    except Exception as e:
+        logger.error(f"An unexpected error occurred during FASTA file generation: {e}")
 
 def __main__():
     args = parse_args()
@@ -639,20 +828,8 @@ def __main__():
     mutated_peptides_df = mutated_peptides_df.rename(columns={"sequence": args.peptide_col_name})
     mutated_peptides_df.to_csv(f"{args.prefix}.tsv", index=False, sep="\t")
 
-    # write mutated protein sequences to fasta file
     if args.fasta_output:
-        with open(f"{args.prefix}.fasta", "w") as protein_outfile:
-            for p in mutated_proteins:
-                variants = []
-                for v in p.vars:
-                    variants += p.vars[v]
-                c = [x.coding.values() for x in variants]
-                cf = list(itertools.chain.from_iterable(c))
-                cds = ",".join([y.cdsMutationSyntax for y in set(cf)])
-                aas = ",".join([y.aaMutationSyntax for y in set(cf)])
-                protein_outfile.write(f">{p.transcript_id}:{aas}:{cds}\n")
-                protein_outfile.write(f"{str(p)}\n")
-
+        generate_fasta_output(f"{args.prefix}.fasta", mutated_proteins, mutated_peptides_df, args.flanking_region_size)
 
 if __name__ == "__main__":
     __main__()

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -616,7 +616,7 @@ def generate_fasta_output(output_filename, mutated_proteins, mutated_peptides_df
         if len(p.vars) == 0:
             # The wildtype sequence is stored directly in fasta_dict since it is not modified further
             fasta_dict.setdefault(transcript_id, {"seq_wt": str(p), "mutations": []})
-        # Mutations with only one variant
+        # Transcript with only one variant
         elif len(p.vars) == 1:
             # Extract relevant mutation details
             variant_detail = next(iter(p.vars.values()))[0]

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -21,7 +21,7 @@ from epytope.EpitopePrediction import EpitopePredictorFactory
 from epytope.IO.ADBAdapter import EIdentifierTypes
 from epytope.IO.MartsAdapter import MartsAdapter
 
-__author__ = "Christopher Mohr, Jonas Scheid"
+__author__ = "Christopher Mohr, Jonas Scheid, Axel Walter"
 VERSION = "2.0"
 
 # Define global variables

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -220,6 +220,7 @@ def read_vcf(filename, pass_only=True):
             # check if we have SNPEFF or VEP annotated variants, otherwise abort
             if record.INFO.get(SNPEFF_KEY, False) or record.INFO.get(VEP_KEY, False):
                 isSynonymous = False
+                consequence = "unknown"
                 coding = dict()
                 types = []
                 # SNPEFF annotation

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -360,7 +360,7 @@ def read_vcf(filename, pass_only=True):
                 for m in metadata_name:
                     vs_new.log_metadata(m, v.get_metadata(m))
                 dict_vars[v] = vs_new
-    
+
     return dict_vars.values(), transcript_ids, final_metadata_list
 
 def create_protein_column_value(pep, database_id):
@@ -649,7 +649,7 @@ def generate_fasta_output(output_filename: str, mutated_proteins: list, mutated_
             # In case of multiple mutations, we want to keep them only if all combinations are close together (within one flanking region)
             # examples (based on flanking_region_size of 25):
             # valid:
-            # positions = [101, 112] 
+            # positions = [101, 112]
             # positions = [50, 64, 71] --> one peptide could span all mutations in theory
             # invalid:
             # positions = [50, 64, 80] --> too far apart, 50 and 80 can not be covered by one peptide, the [50, 64] will appear separatey in the mutated proteins list
@@ -700,7 +700,7 @@ def generate_fasta_output(output_filename: str, mutated_proteins: list, mutated_
         fasta_dict[transcript_id]["uniprot"] = unique_join(peptides_for_transcript["uniprot"])
         fasta_dict[transcript_id]["ensembl_gene"] = unique_join(peptides_for_transcript["gene"])
         fasta_dict[transcript_id]["ensembl_protein"] = unique_join(peptides_for_transcript["proteins"])
-    
+
     # Write the FASTA file
     with open(output_filename, "w") as protein_outfile:
         for transcript, entry in fasta_dict.items():

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -626,6 +626,8 @@ def generate_fasta_output(output_filename: str, mutated_proteins: list, mutated_
             variant_details_protein = []
             variant_positions_protein = []
             variant_consequences = []
+
+            # Collect variant info
             for var_details in p.vars.values():
                 for variant_detail in var_details:
                     variant_consequences.append(variant_detail.get_metadata("consequence")[0])
@@ -633,6 +635,15 @@ def generate_fasta_output(output_filename: str, mutated_proteins: list, mutated_
                         variant_details_gene.append(coding_variant.cdsMutationSyntax)
                         variant_details_protein.append(coding_variant.aaMutationSyntax)
                         variant_positions_protein.append(coding_variant.protPos)
+
+            # Sort all lists based on variant_positions_protein
+            if variant_positions_protein:
+                sorted_indices = sorted(range(len(variant_positions_protein)), key=lambda i: variant_positions_protein[i])
+                variant_details_gene = [variant_details_gene[i] for i in sorted_indices]
+                variant_details_protein = [variant_details_protein[i] for i in sorted_indices]
+                variant_positions_protein = [variant_positions_protein[i] for i in sorted_indices]
+                variant_consequences = [variant_consequences[i] for i in sorted_indices]
+
             # Validation for proteins with multiple variants, single mutations will always pass this test
             valid = True
             # In case of multiple mutations, we want to keep them only if all combinations are close together (within one flanking region)

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -598,9 +598,9 @@ def write_empty_files(args: argparse.Namespace):
         open(f"{args.prefix}.fasta", "w").close()
 
 def update_protein_variant_details_one_codon_triplet(
-    variant_details_protein: List[str], 
+    variant_details_protein: List[str],
     positions: List[int],
-    seq_wt: str, 
+    seq_wt: str,
     seq_mut: str,
     consequences: Union[List[str], None] = None
 ) -> List[str]:
@@ -608,7 +608,7 @@ def update_protein_variant_details_one_codon_triplet(
     Update the protein variant details for a single codon triplet (for missense and stop gained mutations).
 
     In case of multiple mutations in a codon triplet we need to update the variant details
-    to reflect the actual mutation syntax, e.g. "c.241G>T,c.242A>T" currently annotated as "p.Glu81Ter,p.Glu81Val" 
+    to reflect the actual mutation syntax, e.g. "c.241G>T,c.242A>T" currently annotated as "p.Glu81Ter,p.Glu81Val"
     actual combined mutation --> "p.Glu81Leu"
     Without phasing, VEP does not annotate these together, so we have to do it manually for now
 
@@ -625,21 +625,21 @@ def update_protein_variant_details_one_codon_triplet(
     # Input validation
     if not variant_details_protein or not positions:
         return variant_details_protein
-    
+
     if len(variant_details_protein) != len(positions):
         raise ValueError("Length of variant_details_protein must match length of positions")
-    
+
     # Prepare lookup for single-letter to three-letter amino acid codes
     aa1to3 = IUPACData.protein_letters_1to3.copy()
     aa1to3["*"] = "Ter"
-    
+
     # Group positions by their list index values to find duplicates
     position_groups = {}
     for i, pos in enumerate(positions):
         if pos not in position_groups:
             position_groups[pos] = []
         position_groups[pos].append(i)
-    
+
     # Collect updated variants
     updated_variants = []
     # And, if consequences are provided, update them accordingly
@@ -647,7 +647,7 @@ def update_protein_variant_details_one_codon_triplet(
         updated_consequences = []
     else:
         updated_consequences = None
-    
+
     # Iterate over the grouped positions
     for pos, indices in position_groups.items():
         if len(indices) == 1:
@@ -665,22 +665,22 @@ def update_protein_variant_details_one_codon_triplet(
                     if updated_consequences is not None:
                         updated_consequences.extend(consequences[i] for i in indices)
                     continue
-                
+
                 # Get actual amino acids at this position
                 pos_wt = seq_wt[pos - 1]  # Convert to 0-based index
                 pos_mut = seq_mut[pos - 1] if pos <= len(seq_mut) else "*"
-                
+
                 # Convert to three-letter codes
                 pos_wt_3letter = aa1to3.get(pos_wt, pos_wt)
                 pos_mut_3letter = aa1to3.get(pos_mut, pos_mut)
-                
+
                 # Create the combined variant annotation
                 if pos_wt == pos_mut:
                     # Synonymous mutation
                     new_variant = f"p.{pos_wt_3letter}{pos}="
                 else:
                     new_variant = f"p.{pos_wt_3letter}{pos}{pos_mut_3letter}"
-                
+
                 # And update the consequence for the new combined variant
                 updated_variants.append(new_variant)
                 if updated_consequences is not None:
@@ -792,7 +792,7 @@ def generate_fasta_output(output_filename: str, mutated_proteins: list, mutated_
             )
             entry["variants"][i]["details_protein"] = ",".join(new_details)
             entry["variants"][i]["consequences"] = ",".join(new_consequences)
-    
+
     # Splice the sequences around the mutation positions
     for entry in fasta_dict.values():
         for i, variant in enumerate(entry["variants"]):

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -673,6 +673,9 @@ def generate_fasta_output(output_filename: str, mutated_proteins: list, mutated_
                 # And append to the list of variants for the given transcript
                 entry["variants"].append(variant_entry)
 
+    # Remove entries whithout variants
+    fasta_dict = {k: v for k, v in fasta_dict.items() if v["variants"]}
+
     # Get a dataframe to look-up peptides by transcript --> to obtain meta data such as uniprot, ensembl IDs, protein variant notation
     peptides_df_for_lookup = mutated_peptides_df.iloc[:, 1:-1].drop_duplicates()
 

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -627,6 +627,7 @@ def generate_fasta_output(output_filename, mutated_proteins, mutated_peptides_df
                 "variant_details_gene": cds_mutation_syntax
             }
             # Add to list of mutations for this transcript
+            # Multiple variants on one transcript
             temp_mutations_by_transcript.setdefault(transcript_id, []).append(mut_entry)
         elif len(p.vars) > 1:
             # Extract mutation syntax for all variants in the protein

--- a/docs/output.md
+++ b/docs/output.md
@@ -33,7 +33,7 @@ Tables are written per chromosome in a `tsv`.
 
 These generated mutated peptides are then passed to the MHC binding prediction subworkflow, where they are scored against the sample's individual MHC typing.
 
-**Optionally** you can obtain the full mutated and wildtype protein sequence of `ENSP00000235347` by providing `--fasta_output`. This can be specificall useful as input database for mass spectrometry-based pipelines such as [nf-core/mhcquant](https://github.com/nf-core/mhcquant)
+**Optionally** you can obtain a **FASTA** file containing the variant protein sequences by providing `--fasta_output`. This can be specifically useful as input database for mass spectrometry-based pipelines such as [nf-core/mhcquant](https://github.com/nf-core/mhcquant). Sequences will be provided in full length for the wildtype and spliced around the mutation site for variant sequences (`--fasta_peptide_flanking_region_size` parameter).
 
 **Output directory:** `epytope/[sample].fasta`
 

--- a/modules/local/epytope_variant_prediction/main.nf
+++ b/modules/local/epytope_variant_prediction/main.nf
@@ -22,6 +22,7 @@ process EPYTOPE_VARIANT_PREDICTION {
     def prefix = task.ext.prefix ?: "${meta.id}"
     def min_length = (meta.mhc_class == "I") ? params.min_peptide_length_classI : params.min_peptide_length_classII
     def max_length = (meta.mhc_class == "I") ? params.max_peptide_length_classI : params.max_peptide_length_classII
+    def flanking_region_size = params.max_peptide_length_classII // To be sure take the longest peptides possible
 
     """
     epaa.py \
@@ -29,6 +30,7 @@ process EPYTOPE_VARIANT_PREDICTION {
         -p ${prefix} \
         --max_length ${max_length} \
         --min_length ${min_length} \
+        --flanking_region_size ${flanking_region_size} \
         $args
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/epytope_variant_prediction/main.nf
+++ b/modules/local/epytope_variant_prediction/main.nf
@@ -22,7 +22,7 @@ process EPYTOPE_VARIANT_PREDICTION {
     def prefix = task.ext.prefix ?: "${meta.id}"
     def min_length = (meta.mhc_class == "I") ? params.min_peptide_length_classI : params.min_peptide_length_classII
     def max_length = (meta.mhc_class == "I") ? params.max_peptide_length_classI : params.max_peptide_length_classII
-    def flanking_region_size = params.max_peptide_length_classII // To be sure take the longest peptides possible
+    def flanking_region_size = params.fasta_peptide_flanking_region_size
 
     """
     epaa.py \

--- a/nextflow.config
+++ b/nextflow.config
@@ -38,13 +38,13 @@ params {
     max_peptide_length_classI  = 12
     min_peptide_length_classII = 8
     max_peptide_length_classII = 25
-    fasta_peptide_flanking_region_size = 25
 
     // Options: Annotation
     wild_type = true
 
     // Options: Output
     fasta_output = false
+    fasta_peptide_flanking_region_size = 25
 
     // MultiQC options
     multiqc_config              = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -38,6 +38,7 @@ params {
     max_peptide_length_classI  = 12
     min_peptide_length_classII = 8
     max_peptide_length_classII = 25
+    fasta_peptide_flanking_region_size = 25
 
     // Options: Annotation
     wild_type = true

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -92,7 +92,7 @@
                 "max_peptide_length_classII": {
                     "type": "integer",
                     "default": 25,
-                    "description": "Specifies the maximum peptide length for MHC class II peptides."
+                    "description": "Specifies the maximum peptide length for MHC class II peptides. Defines the size of the flanking regions around a mutation in a peptide in the FASTA file (if `fasta_output` is set to `true`)."
                 },
                 "tools": {
                     "type": "string",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -92,7 +92,7 @@
                 "max_peptide_length_classII": {
                     "type": "integer",
                     "default": 25,
-                    "description": "Specifies the maximum peptide length for MHC class II peptides. Defines the size of the flanking regions around a mutation in a peptide in the FASTA file (if `fasta_output` is set to `true`)."
+                    "description": "Specifies the maximum peptide length for MHC class II peptides."
                 },
                 "tools": {
                     "type": "string",
@@ -110,6 +110,12 @@
                     "default": false,
                     "description": "Specifies that sequences of proteins, affected by provided variants, will be written to a FASTA file.",
                     "help_text": "Specifies that sequences of proteins that are affected by the provided genomic variants are written to a `FASTA` file. The resulting `FASTA` file will contain the wild-type and mutated protein sequences. Setting this flag will skip the MHC binding prediction entirely. One can provide arbitrary values for `alleles` and `mhc_class` in the samplesheet."
+                },
+                "fasta_peptide_flanking_region_size": {
+                    "type": "integer",
+                    "default": 25,
+                    "hidden": true,
+                    "description": "Specifies the size of the flanking regions around a mutation in a peptide in the FASTA file (if `fasta_output` is set to `true`)."
                 },
                 "wide_format_output": {
                     "type": "boolean",


### PR DESCRIPTION
This PR is a major rework of the Fasta file output.

- new header structure
- full wildtype sequences, mutatated peptides are cut around the mutation site
- the flanking region size is defined by the largest possible peptide (max class II size)
- overlapping mutations

Example:
```
>sp|P38159_wt|ENSG00000147274|ENST00000320676|ENSP00000359645|P38159
MVEADRPGKLFIGGLNTETNEKALEAVFGKYGRIVEVLLMKDRETNKSRGFAFVTFESPADAKDAARDMNGKSLDGKAIKVEQATKPSFESGRRGPPPPPRSRGPPRGLRGGRGGSGGTRGPPSRGGHMDDGGYSMNFNMSSSRGPLPVKRGPPPRSGGPPPKRSAPSGPVRSSSGMGGRAPVSRGRDSYGGPPRREPLPSRRDVYLSPRDDGYSTKDSYSSRDYPSSRDTRDYAPPPRDYTYRDYGHSSSRDDYPSRGYSDRDGYGRDRDYSDHPSGGSYRDSYESYGNSRSAPPTRGPPPSYGGSSRYDDYSSSRDGYGGSRDSYSSSRSDLYSSGRDRVGRQERGLPPSMERGYPPPRDSYSSSSRGAPRGGGRGGSRSDRGGGRSRY
>sp|P38159_mut_1|ENSG00000147274|ENST00000320676|ENSP00000359645|P38159|c.232G>A|p.Ala78Thr
VTFESPADAKDAARDMNGKSLDGKTIKVEQATKPSFESGRRGPPPPPRSR
>sp|P38159_mut_2|ENSG00000147274|ENST00000320676|ENSP00000359645|P38159|c.343G>A|p.Gly115Arg
SGRRGPPPPPRSRGPPRGLRGGRGRSGGTRGPPSRGGHMDDGGYSMNFNM
>sp|P38159_mut_3|ENSG00000147274|ENST00000320676|ENSP00000359645|P38159|c.232G>A,c.343G>A|p.Ala78Thr,p.Gly115Arg
VTFESPADAKDAARDMNGKSLDGKTIKVEQATKPSFESGRRGPPPPPRSRGPPRGLRGGRGRSGGTRGPPSRGGHMDDGGYSMNFNM
```
## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
