### PR TITLE
Updated label for SUMMARIZE_RESULTS

### DIFF
--- a/modules/local/summarize_results/main.nf
+++ b/modules/local/summarize_results/main.nf
@@ -1,5 +1,5 @@
 process SUMMARIZE_RESULTS {
-    label 'process_single'
+    label 'process_low'
     tag "${meta.id}"
 
     conda "${moduleDir}/environment.yml"


### PR DESCRIPTION
SUMMARIZE_RESULTS sometimes needs quite some RAM and causes the pipeline to crash. I bumped it up to "low" which equals to 12 GB RAM for the first try. This seems to solve it for most samples. 
Still, this step is quite RAM hungry right now.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
