### PR TITLE
suggested change to make rank representative of BA (issue #325)

### DIFF
--- a/modules/local/merge_predictions/templates/merge_predictions.py
+++ b/modules/local/merge_predictions/templates/merge_predictions.py
@@ -197,7 +197,7 @@ class PredictionResult:
         df = pd.read_csv(self.file_path, sep='\t', skiprows=1)
         # Extract Peptide, percentile rank, binding affinity
         df = df[df.columns[df.columns.str.contains('Peptide|BA_Rank|BA-score')]]
-        df = df.rename(columns={'Peptide':self.peptide_col_name,'EL_Rank':'EL_Rank.0','BA-score':'BA-score.0'})
+        df = df.rename(columns={'Peptide':self.peptide_col_name,'BA_Rank':'BA_Rank.0','BA-score':'BA-score.0'})
         # to longformat based on .0|1|2..
         df_long = pd.melt(
             df,

--- a/modules/local/merge_predictions/templates/merge_predictions.py
+++ b/modules/local/merge_predictions/templates/merge_predictions.py
@@ -196,7 +196,7 @@ class PredictionResult:
         # Read the file into a DataFrame with no headers initially
         df = pd.read_csv(self.file_path, sep='\t', skiprows=1)
         # Extract Peptide, percentile rank, binding affinity
-        df = df[df.columns[df.columns.str.contains('Peptide|EL_Rank|BA-score')]]
+        df = df[df.columns[df.columns.str.contains('Peptide|BA_Rank|BA-score')]]
         df = df.rename(columns={'Peptide':self.peptide_col_name,'EL_Rank':'EL_Rank.0','BA-score':'BA-score.0'})
         # to longformat based on .0|1|2..
         df_long = pd.melt(
@@ -209,7 +209,7 @@ class PredictionResult:
 
         # Extract the allele information (e.g., .0, .1, etc.)
         df_long['allele'] = df_long['metric'].str.split('.').str[1]
-        df_long['metric'] = df_long['metric'].apply(lambda x: x.split('.')[0].replace('EL_Rank','rank').replace('BA-score','BA'))
+        df_long['metric'] = df_long['metric'].apply(lambda x: x.split('.')[0].replace('BA_Rank','rank').replace('BA-score','BA'))
 
         # Pivot table to organize columns properly
         df_pivot = df_long.pivot_table(index=[self.peptide_col_name, 'allele'], columns='metric', values='value').reset_index()


### PR DESCRIPTION
Sorry, I've not tested this change, but I think this might solve #325 . Would appreciate someone testing! 

I noticed the intermediate published files, `*_chunk_*_predicted_netmhcpan.xls`, had perfect correlation between `BA-score` and `BA_Rank` columns. However, something was going weird with the output `predictions/*.tsv` files that are created by `merge_prediction.py`. 

After manually merging `*_chunk_*_predicted_netmhcpan.xls` with `predictions/*.tsv` files ,yself, I noticed that the `EL-score` column of the intermediate files perfectly correlated with the `rank` column of the final file. I believe the main focus of this nf-core pipeline is around BA, so I'm submitting this PR to start a fix. Apologies, I'm not familiar with how to work within the nf-core community, so relying on someone else to complete this change. 