### PR TITLE
Add ensembl_dataset parameter to support non-human species

### DIFF
--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -56,6 +56,7 @@ def parse_args():
     parser.add_argument("--min_length", help="Minimum peptide length of mutated peptides", type=int, default=8)
     parser.add_argument("--max_length", help="Maximum peptide length of mutated peptides", type=int, default=14)
     parser.add_argument("--genome_reference", help="Reference, retrieved information will be based on this ensembl version", default="https://grch37.ensembl.org/")
+    parser.add_argument("--ensembl_dataset", help="Ensembl BioMart dataset to use (e.g., hsapiens_gene_ensembl for human, mmusculus_gene_ensembl for mouse)", type=str, default="hsapiens_gene_ensembl")
     parser.add_argument("--proteome_reference", help="Specify reference proteome fasta for self-filtering peptides from variants")
     parser.add_argument("--peptide_col_name", help="Name of the column containing the peptide sequences", type=str, default="sequence")
     parser.add_argument("--version", help="Script version", action="version", version=VERSION)
@@ -515,7 +516,7 @@ def create_peptide_variant_dictionary(peptides):
     return pep_to_variants
 
 
-def generate_peptides_from_variants( variants: Variant, martsadapter: MartsAdapter, metadata: list, minlength: int, maxlength: int ) -> Tuple[pd.DataFrame, list]:
+def generate_peptides_from_variants( variants: Variant, martsadapter: MartsAdapter, metadata: list, minlength: int, maxlength: int, ensembl_dataset: str = "hsapiens_gene_ensembl" ) -> Tuple[pd.DataFrame, list]:
     """
     Generate mutated peptides ranging between min and max length from a list of epytore.Core.Variants.
     Args:
@@ -524,6 +525,7 @@ def generate_peptides_from_variants( variants: Variant, martsadapter: MartsAdapt
         metadata: List of metadata columns to include in the output.
         minlength: Minimum length of peptides to generate.
         maxlength: Maximum length of peptides to generate.
+        ensembl_dataset: Ensembl BioMart dataset (e.g., hsapiens_gene_ensembl, mmusculus_gene_ensembl).
     Returns:
         mutated_peptides_df: DataFrame containing mutated peptides and metadata.
         prots: List of mutated proteins.
@@ -533,7 +535,7 @@ def generate_peptides_from_variants( variants: Variant, martsadapter: MartsAdapt
     transcripts = []
     for v in variants:
         try:
-            transcripts.extend(generator.generate_transcripts_from_variants([v], martsadapter, ID_SYSTEM_USED))
+            transcripts.extend(generator.generate_transcripts_from_variants([v], martsadapter, ID_SYSTEM_USED, db=ensembl_dataset))
         except Exception:
             logger.warning(f"Could not generate transcripts for variant {v}. Skipping.")
     # Try/except for generate_proteins_from_transcripts
@@ -970,7 +972,7 @@ def __main__():
         transcriptProteinTable = martsadapter.get_protein_ids_from_transcripts(transcripts, type=EIdentifierTypes.ENSEMBL)
 
     # Generate mutated peptides from variants
-    mutated_peptides_df, mutated_proteins = generate_peptides_from_variants( variant_list, martsadapter, variants_metadata, args.min_length, args.max_length + 1)
+    mutated_peptides_df, mutated_proteins = generate_peptides_from_variants( variant_list, martsadapter, variants_metadata, args.min_length, args.max_length + 1, args.ensembl_dataset)
 
     # Check if mutated_peptides_df is empty after filtering and write empty files
     if mutated_peptides_df.empty:

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -50,6 +50,7 @@ process {
             genome_reference != 'grch37' & genome_reference != 'grch38' ? "--genome_reference '${genome_reference}'" : '',
             genome_reference == 'grch37'                                ? "--genome_reference 'https://grch37.ensembl.org/'" : '',
             genome_reference == 'grch38'                                ? "--genome_reference 'https://www.ensembl.org'" : '',
+            params.ensembl_dataset                                      ? "--ensembl_dataset '${params.ensembl_dataset}'" : "",
             params.proteome_reference                                   ? "--proteome_reference ${params.proteome_reference}" : "",
             params.fasta_output                                         ? "--fasta_output" : "",
         ].join(' ').trim()

--- a/nextflow.config
+++ b/nextflow.config
@@ -22,6 +22,7 @@ params {
 
     // References
     genome_reference             = 'grch38'
+    ensembl_dataset              = null // Ensembl BioMart dataset (e.g., hsapiens_gene_ensembl for human, mmusculus_gene_ensembl for mouse)
     genome                       = null
 
     // Options: Predictions

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -60,6 +60,11 @@
                     "help_text": "This defines against which human Ensembl genome reference the pipeline performs the analysis including the incorporation of genetic variants. If `grch37` or `grch38` are specified, the most recent Ensembl Biomart version for genome versions will be used. Alternatively, an Ensembl Biomart (archive) version can be specified, e.g. http://jan2020.archive.ensembl.org/.",
                     "description": "Specifies the Ensembl genome reference version that will be used."
                 },
+                "ensembl_dataset": {
+                    "type": "string",
+                    "help_text": "Specifies the Ensembl BioMart dataset to use. For human data, use 'hsapiens_gene_ensembl' (default if not specified). For mouse data, use 'mmusculus_gene_ensembl'. Other species datasets can be found at https://www.ensembl.org/biomart/martview/.",
+                    "description": "Ensembl BioMart dataset for species-specific sequence lookup (e.g., hsapiens_gene_ensembl for human, mmusculus_gene_ensembl for mouse)."
+                },
                 "proteome_reference": {
                     "type": "string",
                     "format": "file-path",


### PR DESCRIPTION
**Description**:                                                                                                                                                
                                                                                                                                                            
**Summary**                                                                                                                                                     
                                                                                                                                                            
- Adds `--ensembl_dataset` parameter to specify the Ensembl BioMart dataset for transcript lookup                                                             
- Fixes empty FASTA output when processing non-human VCF files (e.g., mouse GRCm39)                                                                         
                                                                                                                                                            
**Changes**                                                                                                                                                     
                                                                                                                                                            
- bin/epaa.py: Pass `ensembl_dataset` to `generate_transcripts_from_variants()` instead of hardcoded `hsapiens_gene_ensembl`
- conf/modules.config: Forward parameter to the epytope process                                                                                             
- nextflow.config / nextflow_schema.json: Define new parameter with documentation                                                                           
                                                                                                                                                            
**Usage**                                                                                                                                                       
                                                                                                                                                            
nextflow run nf-core/epitopeprediction \                                                                                                                    
  --ensembl_dataset mmusculus_gene_ensembl \                                                                                                                
  --genome_reference "https://www.ensembl.org" \                                                                                                            
  ...

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
