### PR TITLE
feat: Extract protein IDs from VCF annotations and add genome reference mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#315](https://github.com/nf-core/epitopeprediction/pull/315) Added module bcftools/norm and parameter `--genome` for reference.fasta input ([@SusiJo](https://github.com/SusiJo/))
 - [#316](https://github.com/nf-core/epitopeprediction/pull/316) Added parameter `--biomart_dump_path` for offline biomart usage that addresses issue[#248](https://github.com/nf-core/epitopeprediction/issues/248) ([@SusiJo](https://github.com/SusiJo/))
+- Extract protein IDs (ENSP, UniProt, RefSeq) directly from VCF CSQ annotations as fallback when BioMart lookup fails
+- Genome reference mapping to auto-detect Ensembl URL and dataset from genome name (grch38, grcm38, etc.)
 
 ### `Fixed`
+
+- Fix metadata copying for transcripts with >10 variants causing "unknown" consequence in FASTA output
+- Fix nested list handling in variant metadata preventing TypeError in FASTA generation
+- Add error handling for BioMart API failures to gracefully fall back to VCF annotations
 
 ### `Dependencies`
 
@@ -23,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#316](https://github.com/nf-core/epitopeprediction/pull/316) Added parameter `--biomart_dump` in `epaa.py` ([@SusiJo](https://github.com/SusiJo/)).
 - [#320](https://github.com/nf-core/epitopeprediction/pull/320) Set default genome reference to GRCh38 ([@jonasscheid](https://github.com/jonasscheid/)).
+- Remove `--ensembl_dataset` parameter; Ensembl dataset is now auto-detected from `--genome_reference` (supports human and mouse genomes, or direct Ensembl URL).
 
 ## 3.1.0 - Lustnau - 2025-10-22
 

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -30,6 +30,7 @@ VERSION = "2.0"
 ID_SYSTEM_USED = EIdentifierTypes.ENSEMBL
 transcriptProteinTable = {}
 vcfProteinIds = {}  # Store protein IDs extracted directly from VCF annotations
+vcfConsequences = {}  # Store consequences by (chrom, pos, ref, obs) for lookup in FASTA generation
 
 # Set up logging (epytope uses logging as well, so we have to adapt the existing logger)
 logger = logging.getLogger()
@@ -138,6 +139,7 @@ def read_vcf(filename, pass_only=True):
     """
     global ID_SYSTEM_USED
     global vcfProteinIds
+    global vcfConsequences
 
     vep_header_available = False
     # default VEP fields
@@ -359,6 +361,9 @@ def read_vcf(filename, pass_only=True):
                     )
                     var.gene = gene
                     var.log_metadata("vardbid", variation_dbid)
+                    # Store consequence by variant coordinates for lookup in FASTA generation
+                    # This is needed because epytope may not preserve metadata through protein generation
+                    vcfConsequences[(chromosome, pos, reference, alternative)] = consequence
                     final_metadata_list.append("vardbid")
                     for metadata_name in metadata_list:
                         if metadata_name in record.INFO:
@@ -395,8 +400,13 @@ def read_vcf(filename, pass_only=True):
             for v in vs:
                 vs_new = Variant(v.id, v.type, v.chrom, v.genomePos, v.ref, v.obs, v.coding, True, v.isSynonymous)
                 vs_new.gene = v.gene
-                for m in metadata_name:
+                # Copy all metadata including 'consequence'
+                for m in final_metadata_list:
                     vs_new.log_metadata(m, v.get_metadata(m))
+                # Ensure 'consequence' metadata is preserved
+                consequence_meta = v.get_metadata("consequence")
+                if consequence_meta:
+                    vs_new.log_metadata("consequence", consequence_meta)
                 dict_vars[v] = vs_new
 
     return dict_vars.values(), transcript_ids, final_metadata_list
@@ -810,7 +820,13 @@ def generate_fasta_output(output_filename: str, mutated_proteins: list, mutated_
             for var_details in p.vars.values():
                 for variant_detail in var_details:
                     consequence = variant_detail.get_metadata("consequence")
-                    variant_consequences.append(consequence[0] if consequence else "unknown")
+                    if consequence:
+                        variant_consequences.append(consequence[0])
+                    else:
+                        # Fallback: look up consequence from VCF by variant coordinates
+                        var_key = (variant_detail.chrom, variant_detail.genomePos, variant_detail.ref, variant_detail.obs)
+                        vcf_consequence = vcfConsequences.get(var_key, "unknown")
+                        variant_consequences.append(vcf_consequence)
                     for coding_variant in variant_detail.coding.values():
                         variant_details_gene.append(coding_variant.cdsMutationSyntax)
                         variant_details_protein.append(coding_variant.aaMutationSyntax)

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -32,6 +32,20 @@ transcriptProteinTable = {}
 vcfProteinIds = {}  # Store protein IDs extracted directly from VCF annotations
 vcfConsequences = {}  # Store consequences by (chrom, pos, ref, obs) for lookup in FASTA generation
 
+# Mapping from genome reference names to Ensembl URLs and datasets
+GENOME_REFERENCE_MAP = {
+    # Human genomes
+    "grch38": {"url": "https://www.ensembl.org", "dataset": "hsapiens_gene_ensembl"},
+    "grch37": {"url": "https://grch37.ensembl.org", "dataset": "hsapiens_gene_ensembl"},
+    "hg38": {"url": "https://www.ensembl.org", "dataset": "hsapiens_gene_ensembl"},
+    "hg19": {"url": "https://grch37.ensembl.org", "dataset": "hsapiens_gene_ensembl"},
+    # Mouse genomes
+    "grcm39": {"url": "https://www.ensembl.org", "dataset": "mmusculus_gene_ensembl"},
+    "grcm38": {"url": "https://www.ensembl.org", "dataset": "mmusculus_gene_ensembl"},
+    "mm39": {"url": "https://www.ensembl.org", "dataset": "mmusculus_gene_ensembl"},
+    "mm10": {"url": "https://www.ensembl.org", "dataset": "mmusculus_gene_ensembl"},
+}
+
 def unwrap_to_string(value, default="unknown"):
     """Unwrap nested lists to get a string value.
 
@@ -68,8 +82,7 @@ def parse_args():
     parser.add_argument("--flanking_region_size", help="Size of flanking region around mutated peptides in FASTA output", type=int, default=25)
     parser.add_argument("--min_length", help="Minimum peptide length of mutated peptides", type=int, default=8)
     parser.add_argument("--max_length", help="Maximum peptide length of mutated peptides", type=int, default=14)
-    parser.add_argument("--genome_reference", help="Reference, retrieved information will be based on this ensembl version", default="https://grch37.ensembl.org/")
-    parser.add_argument("--ensembl_dataset", help="Ensembl BioMart dataset to use (e.g., hsapiens_gene_ensembl for human, mmusculus_gene_ensembl for mouse)", type=str, default="hsapiens_gene_ensembl")
+    parser.add_argument("--genome_reference", help="Genome reference (grch38, grch37, hg38, hg19 for human; grcm39, grcm38, mm39, mm10 for mouse)", default="grch38")
     parser.add_argument("--proteome_reference", help="Specify reference proteome fasta for self-filtering peptides from variants")
     parser.add_argument("--peptide_col_name", help="Name of the column containing the peptide sequences", type=str, default="sequence")
     parser.add_argument("--version", help="Script version", action="version", version=VERSION)
@@ -1100,10 +1113,18 @@ def __main__():
         write_empty_files(args)
         return  # Exit early
 
+    # Look up genome reference in the mapping
+    genome_ref_lower = args.genome_reference.lower()
+    if genome_ref_lower not in GENOME_REFERENCE_MAP:
+        logger.error(f"Unknown genome reference: {args.genome_reference}. Supported values: {', '.join(GENOME_REFERENCE_MAP.keys())}")
+        sys.exit(1)
+    genome_info = GENOME_REFERENCE_MAP[genome_ref_lower]
+    ensembl_url = genome_info["url"]
+    ensembl_dataset = genome_info["dataset"]
+    logger.info(f"Using genome reference '{args.genome_reference}' -> Ensembl URL: {ensembl_url}, dataset: {ensembl_dataset}")
+
     # initialize MartsAdapter
-    # in previous version, these were the defaults "GRCh37": "http://feb2014.archive.ensembl.org" (broken)
-    # "GRCh38": "http://apr2018.archive.ensembl.org" (different dataset table scheme, could potentially be fixed on BiomartAdapter level if needed )
-    martsadapter = MartsAdapter(biomart=args.genome_reference)
+    martsadapter = MartsAdapter(biomart=ensembl_url)
 
     if args.biomart_dump:
         logger.info(f"Using offline biomart dump. Loading transcript to protein mapping from {args.biomart_dump}")
@@ -1122,7 +1143,7 @@ def __main__():
     transcriptProteinTable = merge_vcf_protein_ids_with_biomart(transcriptProteinTable, vcfProteinIds, transcripts)
 
     # Generate mutated peptides from variants
-    mutated_peptides_df, mutated_proteins = generate_peptides_from_variants( variant_list, martsadapter, variants_metadata, args.min_length, args.max_length + 1, args.ensembl_dataset)
+    mutated_peptides_df, mutated_proteins = generate_peptides_from_variants( variant_list, martsadapter, variants_metadata, args.min_length, args.max_length + 1, ensembl_dataset)
 
     # Check if mutated_peptides_df is empty after filtering and write empty files
     if mutated_peptides_df.empty:

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -1118,8 +1118,8 @@ def __main__():
 
     # Merge protein IDs from VCF annotations with BioMart results
     # This ensures that protein IDs present in VCF (e.g., ENSP, UniProt) are used when BioMart lookup fails
-    if vcfProteinIds:
-        transcriptProteinTable = merge_vcf_protein_ids_with_biomart(transcriptProteinTable, vcfProteinIds, transcripts)
+    # Always call merge function to ensure transcriptProteinTable is initialized even if BioMart failed
+    transcriptProteinTable = merge_vcf_protein_ids_with_biomart(transcriptProteinTable, vcfProteinIds, transcripts)
 
     # Generate mutated peptides from variants
     mutated_peptides_df, mutated_proteins = generate_peptides_from_variants( variant_list, martsadapter, variants_metadata, args.min_length, args.max_length + 1, args.ensembl_dataset)

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -402,11 +402,15 @@ def read_vcf(filename, pass_only=True):
                 vs_new.gene = v.gene
                 # Copy all metadata including 'consequence'
                 for m in final_metadata_list:
-                    vs_new.log_metadata(m, v.get_metadata(m))
+                    meta_value = v.get_metadata(m)
+                    if meta_value:
+                        # get_metadata returns a list, extract the first element
+                        vs_new.log_metadata(m, meta_value[0] if isinstance(meta_value, list) else meta_value)
                 # Ensure 'consequence' metadata is preserved
                 consequence_meta = v.get_metadata("consequence")
                 if consequence_meta:
-                    vs_new.log_metadata("consequence", consequence_meta)
+                    # get_metadata returns a list, extract the first element
+                    vs_new.log_metadata("consequence", consequence_meta[0] if isinstance(consequence_meta, list) else consequence_meta)
                 dict_vars[v] = vs_new
 
     return dict_vars.values(), transcript_ids, final_metadata_list

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -29,6 +29,7 @@ VERSION = "2.0"
 # Define global variables
 ID_SYSTEM_USED = EIdentifierTypes.ENSEMBL
 transcriptProteinTable = {}
+vcfProteinIds = {}  # Store protein IDs extracted directly from VCF annotations
 
 # Set up logging (epytope uses logging as well, so we have to adapt the existing logger)
 logger = logging.getLogger()
@@ -136,6 +137,7 @@ def read_vcf(filename, pass_only=True):
     :return: list of epytope variants
     """
     global ID_SYSTEM_USED
+    global vcfProteinIds
 
     vep_header_available = False
     # default VEP fields
@@ -310,6 +312,37 @@ def read_vcf(filename, pass_only=True):
                                 transcript_id, tpos, ppos, split_coding_c[-1], split_coding_p[-1]
                             )
                             transcript_ids.append(transcript_id)
+
+                            # Extract protein IDs from VEP annotation fields
+                            if transcript_id not in vcfProteinIds:
+                                vcfProteinIds[transcript_id] = {"ensembl_id": "", "uniprot_id": "", "refseq_id": ""}
+
+                            # Extract Ensembl protein ID from 'ensp' field or HGVSp
+                            ensembl_protein = ""
+                            if "ensp" in vep_fields and len(split_annotation) > vep_fields["ensp"]:
+                                ensembl_protein = split_annotation[vep_fields["ensp"]].split(".")[0]
+                            # Fallback: extract from HGVSp (e.g., ENSMUSP00000150262.2:p.Val3239Arg)
+                            if not ensembl_protein and split_coding_p and len(split_coding_p) > 0:
+                                protein_prefix = split_coding_p[0].split(".")[0]
+                                if protein_prefix.startswith("ENSP") or protein_prefix.startswith("ENSMUSP"):
+                                    ensembl_protein = protein_prefix
+                            if ensembl_protein and not vcfProteinIds[transcript_id]["ensembl_id"]:
+                                vcfProteinIds[transcript_id]["ensembl_id"] = ensembl_protein
+
+                            # Extract UniProt ID from 'swissprot' or 'trembl' fields
+                            uniprot_id = ""
+                            if "swissprot" in vep_fields and len(split_annotation) > vep_fields["swissprot"]:
+                                uniprot_id = split_annotation[vep_fields["swissprot"]].split(".")[0]
+                            if not uniprot_id and "trembl" in vep_fields and len(split_annotation) > vep_fields["trembl"]:
+                                uniprot_id = split_annotation[vep_fields["trembl"]].split(".")[0]
+                            if uniprot_id and not vcfProteinIds[transcript_id]["uniprot_id"]:
+                                vcfProteinIds[transcript_id]["uniprot_id"] = uniprot_id
+
+                            # Extract RefSeq protein ID from 'refseq_match' field if available
+                            if "refseq_match" in vep_fields and len(split_annotation) > vep_fields["refseq_match"]:
+                                refseq_id = split_annotation[vep_fields["refseq_match"]].split(".")[0]
+                                if refseq_id and not vcfProteinIds[transcript_id]["refseq_id"]:
+                                    vcfProteinIds[transcript_id]["refseq_id"] = refseq_id
                 if coding:
                     pos, reference, alternative = get_epytope_annotation(vt, genomic_position, reference, str(alt))
                     var = Variant(
@@ -942,11 +975,86 @@ def get_protein_ids_from_transcripts_offline(transcripts, data_path):
     return result
 
 
+def merge_vcf_protein_ids_with_biomart(biomart_table, vcf_protein_ids, transcripts):
+    """
+    Merge protein IDs extracted from VCF annotations with BioMart lookup results.
+    VCF-derived protein IDs are used as fallback when BioMart doesn't have the mapping.
+
+    Args:
+        biomart_table: DataFrame with protein IDs from BioMart lookup.
+        vcf_protein_ids: Dictionary mapping transcript IDs to protein IDs from VCF.
+        transcripts: List of transcript IDs to process.
+
+    Returns:
+        DataFrame with merged protein IDs.
+    """
+    if biomart_table is None or biomart_table.empty:
+        # Create a new DataFrame from VCF protein IDs
+        rows = []
+        for transcript_id in transcripts:
+            transcript_base = transcript_id.split(".")[0]
+            if transcript_base in vcf_protein_ids:
+                rows.append({
+                    "ensembl_id": vcf_protein_ids[transcript_base].get("ensembl_id", ""),
+                    "refseq_id": vcf_protein_ids[transcript_base].get("refseq_id", ""),
+                    "uniprot_id": vcf_protein_ids[transcript_base].get("uniprot_id", ""),
+                    "transcript_id": transcript_base
+                })
+            else:
+                rows.append({
+                    "ensembl_id": "",
+                    "refseq_id": "",
+                    "uniprot_id": "",
+                    "transcript_id": transcript_base
+                })
+        if rows:
+            logger.info(f"Using {len([r for r in rows if r['ensembl_id'] or r['uniprot_id']])} protein IDs from VCF annotations.")
+            return pd.DataFrame(rows)
+        return pd.DataFrame(columns=["ensembl_id", "refseq_id", "uniprot_id", "transcript_id"])
+
+    # Merge VCF protein IDs into BioMart results
+    merged_count = 0
+    for transcript_id in transcripts:
+        transcript_base = transcript_id.split(".")[0]
+        if transcript_base not in vcf_protein_ids:
+            continue
+
+        vcf_ids = vcf_protein_ids[transcript_base]
+
+        # Check if this transcript exists in BioMart table
+        mask = biomart_table["transcript_id"] == transcript_base
+        if mask.any():
+            # Update empty values with VCF-derived IDs
+            for col, vcf_key in [("ensembl_id", "ensembl_id"), ("uniprot_id", "uniprot_id"), ("refseq_id", "refseq_id")]:
+                if vcf_ids.get(vcf_key):
+                    # Only update if BioMart value is empty/NaN
+                    current_val = biomart_table.loc[mask, col].iloc[0]
+                    if pd.isna(current_val) or current_val == "":
+                        biomart_table.loc[mask, col] = vcf_ids[vcf_key]
+                        merged_count += 1
+        else:
+            # Add new row for transcript not in BioMart
+            new_row = pd.DataFrame([{
+                "ensembl_id": vcf_ids.get("ensembl_id", ""),
+                "refseq_id": vcf_ids.get("refseq_id", ""),
+                "uniprot_id": vcf_ids.get("uniprot_id", ""),
+                "transcript_id": transcript_base
+            }])
+            biomart_table = pd.concat([biomart_table, new_row], ignore_index=True)
+            merged_count += 1
+
+    if merged_count > 0:
+        logger.info(f"Merged {merged_count} protein ID(s) from VCF annotations into BioMart results.")
+
+    return biomart_table
+
+
 def __main__():
     args = parse_args()
     logger.info("Running variant prediction version: " + str(VERSION))
 
     global transcriptProteinTable
+    global vcfProteinIds
 
     # Read VCF file
     variant_list, transcripts, variants_metadata = read_vcf(args.input)
@@ -970,6 +1078,11 @@ def __main__():
     else:
         # Create a mapping of transcript IDs to ensembl, refseq, and uniprot IDs
         transcriptProteinTable = martsadapter.get_protein_ids_from_transcripts(transcripts, type=EIdentifierTypes.ENSEMBL)
+
+    # Merge protein IDs from VCF annotations with BioMart results
+    # This ensures that protein IDs present in VCF (e.g., ENSP, UniProt) are used when BioMart lookup fails
+    if vcfProteinIds:
+        transcriptProteinTable = merge_vcf_protein_ids_with_biomart(transcriptProteinTable, vcfProteinIds, transcripts)
 
     # Generate mutated peptides from variants
     mutated_peptides_df, mutated_proteins = generate_peptides_from_variants( variant_list, martsadapter, variants_metadata, args.min_length, args.max_length + 1, args.ensembl_dataset)

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -39,11 +39,11 @@ GENOME_REFERENCE_MAP = {
     "grch37": {"url": "https://grch37.ensembl.org", "dataset": "hsapiens_gene_ensembl"},
     "hg38": {"url": "https://www.ensembl.org", "dataset": "hsapiens_gene_ensembl"},
     "hg19": {"url": "https://grch37.ensembl.org", "dataset": "hsapiens_gene_ensembl"},
-    # Mouse genomes
+    # Mouse genomes (GRCm39 is current; GRCm38 uses Ensembl 102 archive - last release with GRCm38)
     "grcm39": {"url": "https://www.ensembl.org", "dataset": "mmusculus_gene_ensembl"},
-    "grcm38": {"url": "https://www.ensembl.org", "dataset": "mmusculus_gene_ensembl"},
+    "grcm38": {"url": "https://nov2020.archive.ensembl.org", "dataset": "mmusculus_gene_ensembl"},
     "mm39": {"url": "https://www.ensembl.org", "dataset": "mmusculus_gene_ensembl"},
-    "mm10": {"url": "https://www.ensembl.org", "dataset": "mmusculus_gene_ensembl"},
+    "mm10": {"url": "https://nov2020.archive.ensembl.org", "dataset": "mmusculus_gene_ensembl"},
 }
 
 def unwrap_to_string(value, default="unknown"):

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -82,7 +82,7 @@ def parse_args():
     parser.add_argument("--flanking_region_size", help="Size of flanking region around mutated peptides in FASTA output", type=int, default=25)
     parser.add_argument("--min_length", help="Minimum peptide length of mutated peptides", type=int, default=8)
     parser.add_argument("--max_length", help="Maximum peptide length of mutated peptides", type=int, default=14)
-    parser.add_argument("--genome_reference", help="Genome reference (grch38, grch37, hg38, hg19 for human; grcm39, grcm38, mm39, mm10 for mouse)", default="grch38")
+    parser.add_argument("--genome_reference", help="Genome reference (grch38, grch37, hg38, hg19 for human; grcm39, grcm38, mm39, mm10 for mouse) or Ensembl URL (defaults to human)", default="grch38")
     parser.add_argument("--proteome_reference", help="Specify reference proteome fasta for self-filtering peptides from variants")
     parser.add_argument("--peptide_col_name", help="Name of the column containing the peptide sequences", type=str, default="sequence")
     parser.add_argument("--version", help="Script version", action="version", version=VERSION)
@@ -1113,15 +1113,21 @@ def __main__():
         write_empty_files(args)
         return  # Exit early
 
-    # Look up genome reference in the mapping
+    # Look up genome reference in the mapping or use URL directly
     genome_ref_lower = args.genome_reference.lower()
-    if genome_ref_lower not in GENOME_REFERENCE_MAP:
-        logger.error(f"Unknown genome reference: {args.genome_reference}. Supported values: {', '.join(GENOME_REFERENCE_MAP.keys())}")
+    if genome_ref_lower in GENOME_REFERENCE_MAP:
+        genome_info = GENOME_REFERENCE_MAP[genome_ref_lower]
+        ensembl_url = genome_info["url"]
+        ensembl_dataset = genome_info["dataset"]
+        logger.info(f"Using genome reference '{args.genome_reference}' -> Ensembl URL: {ensembl_url}, dataset: {ensembl_dataset}")
+    elif genome_ref_lower.startswith("http"):
+        # URL provided directly, default to human dataset
+        ensembl_url = args.genome_reference
+        ensembl_dataset = "hsapiens_gene_ensembl"
+        logger.info(f"Using Ensembl URL directly: {ensembl_url}, defaulting to human dataset: {ensembl_dataset}")
+    else:
+        logger.error(f"Unknown genome reference: {args.genome_reference}. Supported values: {', '.join(GENOME_REFERENCE_MAP.keys())} or an Ensembl URL")
         sys.exit(1)
-    genome_info = GENOME_REFERENCE_MAP[genome_ref_lower]
-    ensembl_url = genome_info["url"]
-    ensembl_dataset = genome_info["dataset"]
-    logger.info(f"Using genome reference '{args.genome_reference}' -> Ensembl URL: {ensembl_url}, dataset: {ensembl_dataset}")
 
     # initialize MartsAdapter
     martsadapter = MartsAdapter(biomart=ensembl_url)

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -1110,7 +1110,11 @@ def __main__():
         transcriptProteinTable = get_protein_ids_from_transcripts_offline(transcripts, args.biomart_dump)
     else:
         # Create a mapping of transcript IDs to ensembl, refseq, and uniprot IDs
-        transcriptProteinTable = martsadapter.get_protein_ids_from_transcripts(transcripts, type=EIdentifierTypes.ENSEMBL)
+        try:
+            transcriptProteinTable = martsadapter.get_protein_ids_from_transcripts(transcripts, type=EIdentifierTypes.ENSEMBL)
+        except Exception as e:
+            logger.warning(f"BioMart lookup failed: {e}. Will use protein IDs from VCF annotations if available.")
+            transcriptProteinTable = None
 
     # Merge protein IDs from VCF annotations with BioMart results
     # This ensures that protein IDs present in VCF (e.g., ENSP, UniProt) are used when BioMart lookup fails

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -56,6 +56,7 @@ def parse_args():
     parser.add_argument("--min_length", help="Minimum peptide length of mutated peptides", type=int, default=8)
     parser.add_argument("--max_length", help="Maximum peptide length of mutated peptides", type=int, default=14)
     parser.add_argument("--genome_reference", help="Reference, retrieved information will be based on this ensembl version", default="https://grch37.ensembl.org/")
+    parser.add_argument("--ensembl_dataset", help="Ensembl BioMart dataset to use (e.g., hsapiens_gene_ensembl for human, mmusculus_gene_ensembl for mouse)", type=str, default="hsapiens_gene_ensembl")
     parser.add_argument("--proteome_reference", help="Specify reference proteome fasta for self-filtering peptides from variants")
     parser.add_argument("--peptide_col_name", help="Name of the column containing the peptide sequences", type=str, default="sequence")
     parser.add_argument("--version", help="Script version", action="version", version=VERSION)
@@ -515,7 +516,7 @@ def create_peptide_variant_dictionary(peptides):
     return pep_to_variants
 
 
-def generate_peptides_from_variants( variants: Variant, martsadapter: MartsAdapter, metadata: list, minlength: int, maxlength: int ) -> Tuple[pd.DataFrame, list]:
+def generate_peptides_from_variants( variants: Variant, martsadapter: MartsAdapter, metadata: list, minlength: int, maxlength: int, ensembl_dataset: str = "hsapiens_gene_ensembl" ) -> Tuple[pd.DataFrame, list]:
     """
     Generate mutated peptides ranging between min and max length from a list of epytore.Core.Variants.
     Args:
@@ -524,6 +525,7 @@ def generate_peptides_from_variants( variants: Variant, martsadapter: MartsAdapt
         metadata: List of metadata columns to include in the output.
         minlength: Minimum length of peptides to generate.
         maxlength: Maximum length of peptides to generate.
+        ensembl_dataset: Ensembl BioMart dataset (e.g., hsapiens_gene_ensembl, mmusculus_gene_ensembl).
     Returns:
         mutated_peptides_df: DataFrame containing mutated peptides and metadata.
         prots: List of mutated proteins.
@@ -533,7 +535,7 @@ def generate_peptides_from_variants( variants: Variant, martsadapter: MartsAdapt
     transcripts = []
     for v in variants:
         try:
-            transcripts.extend(generator.generate_transcripts_from_variants([v], martsadapter, ID_SYSTEM_USED))
+            transcripts.extend(generator.generate_transcripts_from_variants([v], martsadapter, ID_SYSTEM_USED, db=ensembl_dataset))
         except Exception:
             logger.warning(f"Could not generate transcripts for variant {v}. Skipping.")
     # Try/except for generate_proteins_from_transcripts
@@ -970,7 +972,7 @@ def __main__():
         transcriptProteinTable = martsadapter.get_protein_ids_from_transcripts(transcripts, type=EIdentifierTypes.ENSEMBL)
 
     # Generate mutated peptides from variants
-    mutated_peptides_df, mutated_proteins = generate_peptides_from_variants( variant_list, martsadapter, variants_metadata, args.min_length, args.max_length + 1)
+    mutated_peptides_df, mutated_proteins = generate_peptides_from_variants( variant_list, martsadapter, variants_metadata, args.min_length, args.max_length + 1, args.ensembl_dataset)
 
     # Check if mutated_peptides_df is empty after filtering and write empty files
     if mutated_peptides_df.empty:

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -795,6 +795,7 @@ def generate_fasta_output(output_filename: str, mutated_proteins: list, mutated_
         mutated_peptides_df (pd.DataFrame): A DataFrame containing peptide-related information such as accessions.
         flanking_region_size (int): The size of the flanking region added on each side of a mutation within a peptide.
     """
+    global vcfConsequences
 
     # Build FASTA dict: wildtypes and mutations per transcript
     fasta_dict = {}

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -32,6 +32,17 @@ transcriptProteinTable = {}
 vcfProteinIds = {}  # Store protein IDs extracted directly from VCF annotations
 vcfConsequences = {}  # Store consequences by (chrom, pos, ref, obs) for lookup in FASTA generation
 
+def unwrap_to_string(value, default="unknown"):
+    """Unwrap nested lists to get a string value.
+
+    get_metadata() returns values wrapped in lists, and if metadata was
+    copied incorrectly, values can become double-wrapped. This function
+    safely extracts the string regardless of nesting level.
+    """
+    while isinstance(value, list) and len(value) > 0:
+        value = value[0]
+    return value if isinstance(value, str) else default
+
 # Set up logging (epytope uses logging as well, so we have to adapt the existing logger)
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -404,13 +415,13 @@ def read_vcf(filename, pass_only=True):
                 for m in final_metadata_list:
                     meta_value = v.get_metadata(m)
                     if meta_value:
-                        # get_metadata returns a list, extract the first element
-                        vs_new.log_metadata(m, meta_value[0] if isinstance(meta_value, list) else meta_value)
+                        # Use unwrap_to_string to handle potentially nested lists
+                        vs_new.log_metadata(m, unwrap_to_string(meta_value, default=""))
                 # Ensure 'consequence' metadata is preserved
                 consequence_meta = v.get_metadata("consequence")
                 if consequence_meta:
-                    # get_metadata returns a list, extract the first element
-                    vs_new.log_metadata("consequence", consequence_meta[0] if isinstance(consequence_meta, list) else consequence_meta)
+                    # Use unwrap_to_string to handle potentially nested lists
+                    vs_new.log_metadata("consequence", unwrap_to_string(consequence_meta))
                 dict_vars[v] = vs_new
 
     return dict_vars.values(), transcript_ids, final_metadata_list
@@ -826,7 +837,8 @@ def generate_fasta_output(output_filename: str, mutated_proteins: list, mutated_
                 for variant_detail in var_details:
                     consequence = variant_detail.get_metadata("consequence")
                     if consequence:
-                        variant_consequences.append(consequence[0])
+                        # Use unwrap_to_string to handle potentially nested lists
+                        variant_consequences.append(unwrap_to_string(consequence))
                     else:
                         # Fallback: look up consequence from VCF by variant coordinates
                         var_key = (variant_detail.chrom, variant_detail.genomePos, variant_detail.ref, variant_detail.obs)

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -47,10 +47,7 @@ process {
     withName: EPYTOPE_VARIANT_PREDICTION {
         ext.prefix = {"${meta.id}_${vcf.baseName}"}
         ext.args   = [
-            genome_reference != 'grch37' & genome_reference != 'grch38' ? "--genome_reference '${genome_reference}'" : '',
-            genome_reference == 'grch37'                                ? "--genome_reference 'https://grch37.ensembl.org/'" : '',
-            genome_reference == 'grch38'                                ? "--genome_reference 'https://www.ensembl.org'" : '',
-            params.ensembl_dataset                                      ? "--ensembl_dataset '${params.ensembl_dataset}'" : "",
+            "--genome_reference '${genome_reference}'",
             params.proteome_reference                                   ? "--proteome_reference ${params.proteome_reference}" : "",
             params.fasta_output                                         ? "--fasta_output" : "",
         ].join(' ').trim()

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -50,6 +50,7 @@ process {
             genome_reference != 'grch37' & genome_reference != 'grch38' ? "--genome_reference '${genome_reference}'" : '',
             genome_reference == 'grch37'                                ? "--genome_reference 'https://grch37.ensembl.org/'" : '',
             genome_reference == 'grch38'                                ? "--genome_reference 'https://www.ensembl.org'" : '',
+            params.ensembl_dataset                                      ? "--ensembl_dataset '${params.ensembl_dataset}'" : "",
             params.proteome_reference                                   ? "--proteome_reference ${params.proteome_reference}" : "",
             params.fasta_output                                         ? "--fasta_output" : "",
         ].join(' ').trim()

--- a/conf/test_fasta_output_grcm39.config
+++ b/conf/test_fasta_output_grcm39.config
@@ -1,0 +1,21 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Nextflow config file for running full-size tests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Defines input files and everything required to run a full size pipeline test.
+
+    Use as follows:
+        nextflow run nf-core/epitopeprediction -profile test_fasta_output,<docker/singularity> --outdir <OUTDIR>
+
+----------------------------------------------------------------------------------------
+*/
+
+params {
+    config_profile_name        = 'Fasta Output GRCm39'
+    config_profile_description = 'Test profile for Fasta output generation with mouse variants (GRCm39)'
+
+    // Input data
+    input = params.pipelines_testdata_base_path + 'epitopeprediction/testdata/sample_sheets/sample_sheet_fasta_output_grcm39.csv'
+    fasta_output = true
+    genome_reference = 'grcm39'
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -376,6 +376,9 @@ co2footprint {
 validation {
     //defaultIgnoreParams = ["genomes"]
     monochromeLogs = params.monochrome_logs
+    help {
+        enabled = true
+    }
 }
 
 // Load modules.config for DSL2 module specific options

--- a/nextflow.config
+++ b/nextflow.config
@@ -211,6 +211,7 @@ profiles {
     test_wide_format_output { includeConfig 'conf/test_wide_format_output.config' }
     test_full               { includeConfig 'conf/test_full.config' }
     test_fasta_output       { includeConfig 'conf/test_fasta_output.config' }
+    test_fasta_output_grcm39 { includeConfig 'conf/test_fasta_output_grcm39.config' }
 }
 
 // Load nf-core custom profiles from different institutions

--- a/nextflow.config
+++ b/nextflow.config
@@ -21,8 +21,7 @@ params {
     biomart_dump_path            = null // Path to local Biomart dump (for offline usage)
 
     // References
-    genome_reference             = 'grch38'
-    ensembl_dataset              = null // Ensembl BioMart dataset (e.g., hsapiens_gene_ensembl for human, mmusculus_gene_ensembl for mouse)
+    genome_reference             = 'grch38' // Supported: grch38, grch37, hg38, hg19 (human), grcm39, grcm38, mm39, mm10 (mouse)
     genome                       = null
 
     // Options: Predictions

--- a/nextflow.config
+++ b/nextflow.config
@@ -22,6 +22,7 @@ params {
 
     // References
     genome_reference             = 'grch38'
+    ensembl_dataset              = null // Ensembl BioMart dataset (e.g., hsapiens_gene_ensembl for human, mmusculus_gene_ensembl for mouse)
     genome                       = null
 
     // Options: Predictions

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -60,6 +60,11 @@
                     "help_text": "This defines against which human Ensembl genome reference the pipeline performs the analysis including the incorporation of genetic variants. If `grch37` or `grch38` are specified, the most recent Ensembl Biomart version for genome versions will be used. Alternatively, an Ensembl Biomart (archive) version can be specified, e.g. http://jan2020.archive.ensembl.org/.",
                     "description": "Specifies the Ensembl genome reference version that will be used."
                 },
+                "ensembl_dataset": {
+                    "type": "string",
+                    "help_text": "Specifies the Ensembl BioMart dataset to use. For human data, use 'hsapiens_gene_ensembl' (default if not specified). For mouse data, use 'mmusculus_gene_ensembl'. Other species datasets can be found at https://www.ensembl.org/biomart/martview/.",
+                    "description": "Ensembl BioMart dataset for species-specific sequence lookup (e.g., hsapiens_gene_ensembl for human, mmusculus_gene_ensembl for mouse)."
+                },
                 "proteome_reference": {
                     "type": "string",
                     "format": "file-path",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -57,9 +57,8 @@
                 "genome_reference": {
                     "type": "string",
                     "default": "grch38",
-                    "enum": ["grch38", "grch37", "hg38", "hg19", "grcm39", "grcm38", "mm39", "mm10"],
-                    "help_text": "This defines the genome reference for the analysis. Human genomes (grch38, grch37, hg38, hg19) use the hsapiens_gene_ensembl dataset. Mouse genomes (grcm39, grcm38, mm39, mm10) use the mmusculus_gene_ensembl dataset. The Ensembl URL and dataset are automatically determined based on this parameter.",
-                    "description": "Specifies the genome reference (human: grch38, grch37, hg38, hg19; mouse: grcm39, grcm38, mm39, mm10)."
+                    "help_text": "This defines the genome reference for the analysis. Human genomes (grch38, grch37, hg38, hg19) use the hsapiens_gene_ensembl dataset. Mouse genomes (grcm39, grcm38, mm39, mm10) use the mmusculus_gene_ensembl dataset. Alternatively, an Ensembl URL can be provided directly (e.g., https://www.ensembl.org), which defaults to the human dataset.",
+                    "description": "Specifies the genome reference (human: grch38, grch37, hg38, hg19; mouse: grcm39, grcm38, mm39, mm10) or an Ensembl URL."
                 },
                 "proteome_reference": {
                     "type": "string",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -57,13 +57,9 @@
                 "genome_reference": {
                     "type": "string",
                     "default": "grch38",
-                    "help_text": "This defines against which human Ensembl genome reference the pipeline performs the analysis including the incorporation of genetic variants. If `grch37` or `grch38` are specified, the most recent Ensembl Biomart version for genome versions will be used. Alternatively, an Ensembl Biomart (archive) version can be specified, e.g. http://jan2020.archive.ensembl.org/.",
-                    "description": "Specifies the Ensembl genome reference version that will be used."
-                },
-                "ensembl_dataset": {
-                    "type": "string",
-                    "help_text": "Specifies the Ensembl BioMart dataset to use. For human data, use 'hsapiens_gene_ensembl' (default if not specified). For mouse data, use 'mmusculus_gene_ensembl'. Other species datasets can be found at https://www.ensembl.org/biomart/martview/.",
-                    "description": "Ensembl BioMart dataset for species-specific sequence lookup (e.g., hsapiens_gene_ensembl for human, mmusculus_gene_ensembl for mouse)."
+                    "enum": ["grch38", "grch37", "hg38", "hg19", "grcm39", "grcm38", "mm39", "mm10"],
+                    "help_text": "This defines the genome reference for the analysis. Human genomes (grch38, grch37, hg38, hg19) use the hsapiens_gene_ensembl dataset. Mouse genomes (grcm39, grcm38, mm39, mm10) use the mmusculus_gene_ensembl dataset. The Ensembl URL and dataset are automatically determined based on this parameter.",
+                    "description": "Specifies the genome reference (human: grch38, grch37, hg38, hg19; mouse: grcm39, grcm38, mm39, mm10)."
                 },
                 "proteome_reference": {
                     "type": "string",

--- a/tests/fasta_output_grcm39.nf.test
+++ b/tests/fasta_output_grcm39.nf.test
@@ -1,0 +1,36 @@
+nextflow_pipeline {
+
+    name "Test pipeline"
+    script "../main.nf"
+    tag "pipeline"
+    profile "test_fasta_output_grcm39"
+
+    test("-profile test_fasta_output_grcm39") {
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+        }
+
+        then {
+            // stable_name: All files + folders in ${params.outdir}/ with a stable name
+            def stable_name = getAllFilesFromDir(params.outdir, relative: true, includeDir: true, ignore: ['pipeline_info/*.{html,json,txt}'])
+            // stable_path: All files in ${params.outdir}/ with stable content
+            def stable_path = getAllFilesFromDir(params.outdir, ignoreFile: 'tests/.nftignore')
+            assertAll(
+                { assert workflow.success},
+                { assert snapshot(
+                    // Number of successful tasks
+                    workflow.trace.succeeded().size(),
+                    // pipeline versions.yml file for multiqc from which Nextflow version is removed because we test pipelines on multiple Nextflow versions
+                    removeNextflowVersion("$outputDir/pipeline_info/nf_core_epitopeprediction_software_mqc_versions.yml"),
+                    // All stable path name, with a relative path
+                    stable_name,
+                    // All files with stable contents
+                    stable_path
+                ).match() }
+            )
+        }
+    }
+}

--- a/tests/fasta_output_grcm39.nf.test.snap
+++ b/tests/fasta_output_grcm39.nf.test.snap
@@ -1,0 +1,121 @@
+{
+    "-profile test_fasta_output_grcm39": {
+        "content": [
+            25,
+            {
+                "BCFTOOLS_STATS": {
+                    "bcftools": 1.22
+                },
+                "CAT_FASTA": {
+                    "pigz": "2.3.4"
+                },
+                "EPYTOPE_VARIANT_PREDICTION": {
+                    "python": "3.7.12",
+                    "epytope": "3.3.1",
+                    "pandas": "1.3.5",
+                    "pyvcf": "1.0.3"
+                },
+                "SNPSIFT_SPLIT": {
+                    "snpsift": 4.3
+                },
+                "Workflow": {
+                    "nf-core/epitopeprediction": "v3.2.0dev"
+                }
+            },
+            [
+                "epytope",
+                "epytope/variants_vep_grcm39.fasta",
+                "epytope/variants_vep_grcm39_variants_vep_grcm39.1.tsv",
+                "epytope/variants_vep_grcm39_variants_vep_grcm39.10.tsv",
+                "epytope/variants_vep_grcm39_variants_vep_grcm39.11.tsv",
+                "epytope/variants_vep_grcm39_variants_vep_grcm39.12.tsv",
+                "epytope/variants_vep_grcm39_variants_vep_grcm39.13.tsv",
+                "epytope/variants_vep_grcm39_variants_vep_grcm39.14.tsv",
+                "epytope/variants_vep_grcm39_variants_vep_grcm39.15.tsv",
+                "epytope/variants_vep_grcm39_variants_vep_grcm39.16.tsv",
+                "epytope/variants_vep_grcm39_variants_vep_grcm39.17.tsv",
+                "epytope/variants_vep_grcm39_variants_vep_grcm39.18.tsv",
+                "epytope/variants_vep_grcm39_variants_vep_grcm39.19.tsv",
+                "epytope/variants_vep_grcm39_variants_vep_grcm39.2.tsv",
+                "epytope/variants_vep_grcm39_variants_vep_grcm39.3.tsv",
+                "epytope/variants_vep_grcm39_variants_vep_grcm39.4.tsv",
+                "epytope/variants_vep_grcm39_variants_vep_grcm39.5.tsv",
+                "epytope/variants_vep_grcm39_variants_vep_grcm39.6.tsv",
+                "epytope/variants_vep_grcm39_variants_vep_grcm39.7.tsv",
+                "epytope/variants_vep_grcm39_variants_vep_grcm39.8.tsv",
+                "epytope/variants_vep_grcm39_variants_vep_grcm39.9.tsv",
+                "epytope/variants_vep_grcm39_variants_vep_grcm39.X.tsv",
+                "epytope/variants_vep_grcm39_variants_vep_grcm39.Y.tsv",
+                "multiqc",
+                "multiqc/multiqc_data",
+                "multiqc/multiqc_data/bcftools-stats-subtypes.txt",
+                "multiqc/multiqc_data/bcftools_stats_indel-lengths.txt",
+                "multiqc/multiqc_data/bcftools_stats_variant_depths.txt",
+                "multiqc/multiqc_data/bcftools_stats_vqc_Count_Indels.txt",
+                "multiqc/multiqc_data/bcftools_stats_vqc_Count_SNP.txt",
+                "multiqc/multiqc_data/bcftools_stats_vqc_Count_Transitions.txt",
+                "multiqc/multiqc_data/bcftools_stats_vqc_Count_Transversions.txt",
+                "multiqc/multiqc_data/llms-full.txt",
+                "multiqc/multiqc_data/multiqc.log",
+                "multiqc/multiqc_data/multiqc.parquet",
+                "multiqc/multiqc_data/multiqc_bcftools_stats.txt",
+                "multiqc/multiqc_data/multiqc_citations.txt",
+                "multiqc/multiqc_data/multiqc_data.json",
+                "multiqc/multiqc_data/multiqc_general_stats.txt",
+                "multiqc/multiqc_data/multiqc_software_versions.txt",
+                "multiqc/multiqc_data/multiqc_sources.txt",
+                "multiqc/multiqc_plots",
+                "multiqc/multiqc_plots/pdf",
+                "multiqc/multiqc_plots/pdf/bcftools-stats-subtypes-cnt.pdf",
+                "multiqc/multiqc_plots/pdf/bcftools-stats-subtypes-pct.pdf",
+                "multiqc/multiqc_plots/pdf/bcftools_stats_indel-lengths-cnt.pdf",
+                "multiqc/multiqc_plots/pdf/bcftools_stats_indel-lengths-log.pdf",
+                "multiqc/multiqc_plots/pdf/bcftools_stats_variant_depths.pdf",
+                "multiqc/multiqc_plots/pdf/bcftools_stats_vqc_Count_Indels.pdf",
+                "multiqc/multiqc_plots/pdf/bcftools_stats_vqc_Count_SNP.pdf",
+                "multiqc/multiqc_plots/pdf/bcftools_stats_vqc_Count_Transitions.pdf",
+                "multiqc/multiqc_plots/pdf/bcftools_stats_vqc_Count_Transversions.pdf",
+                "multiqc/multiqc_plots/png",
+                "multiqc/multiqc_plots/png/bcftools-stats-subtypes-cnt.png",
+                "multiqc/multiqc_plots/png/bcftools-stats-subtypes-pct.png",
+                "multiqc/multiqc_plots/png/bcftools_stats_indel-lengths-cnt.png",
+                "multiqc/multiqc_plots/png/bcftools_stats_indel-lengths-log.png",
+                "multiqc/multiqc_plots/png/bcftools_stats_variant_depths.png",
+                "multiqc/multiqc_plots/png/bcftools_stats_vqc_Count_Indels.png",
+                "multiqc/multiqc_plots/png/bcftools_stats_vqc_Count_SNP.png",
+                "multiqc/multiqc_plots/png/bcftools_stats_vqc_Count_Transitions.png",
+                "multiqc/multiqc_plots/png/bcftools_stats_vqc_Count_Transversions.png",
+                "multiqc/multiqc_plots/svg",
+                "multiqc/multiqc_plots/svg/bcftools-stats-subtypes-cnt.svg",
+                "multiqc/multiqc_plots/svg/bcftools-stats-subtypes-pct.svg",
+                "multiqc/multiqc_plots/svg/bcftools_stats_indel-lengths-cnt.svg",
+                "multiqc/multiqc_plots/svg/bcftools_stats_indel-lengths-log.svg",
+                "multiqc/multiqc_plots/svg/bcftools_stats_variant_depths.svg",
+                "multiqc/multiqc_plots/svg/bcftools_stats_vqc_Count_Indels.svg",
+                "multiqc/multiqc_plots/svg/bcftools_stats_vqc_Count_SNP.svg",
+                "multiqc/multiqc_plots/svg/bcftools_stats_vqc_Count_Transitions.svg",
+                "multiqc/multiqc_plots/svg/bcftools_stats_vqc_Count_Transversions.svg",
+                "multiqc/multiqc_report.html",
+                "pipeline_info",
+                "pipeline_info/nf_core_epitopeprediction_software_mqc_versions.yml"
+            ],
+            [
+                "bcftools-stats-subtypes.txt:md5,36099bc798c3f0a2dbc0adba3f12a781",
+                "bcftools_stats_indel-lengths.txt:md5,a0167f78ffb90d426b87210598c3a404",
+                "bcftools_stats_variant_depths.txt:md5,53f48426977a44f7b24be10d24cc5d5c",
+                "bcftools_stats_vqc_Count_Indels.txt:md5,1017d2b6fd8288a69204989443cbb071",
+                "bcftools_stats_vqc_Count_SNP.txt:md5,87bacac5a3564da60a3d2b875d197174",
+                "bcftools_stats_vqc_Count_Transitions.txt:md5,e301b8c8760fdd149b2e8924d8f9e9b7",
+                "bcftools_stats_vqc_Count_Transversions.txt:md5,fa49ad1a18a4b9cf7d84f05d0018de30",
+                "multiqc_bcftools_stats.txt:md5,802b8594e334574f260d470e145e0c4a",
+                "multiqc_citations.txt:md5,5cbab4ecbe14049d965fd97bd61d252b",
+                "multiqc_general_stats.txt:md5,ddd914edcabcf1eec70d03dc47c812a4"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.3"
+        },
+        "timestamp": "2026-02-05T15:14:58.292105289"
+    }
+}

--- a/tests/nextflow.config
+++ b/tests/nextflow.config
@@ -6,7 +6,7 @@
 
 params {
     modules_testdata_base_path = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/'
-    pipelines_testdata_base_path = 'https://raw.githubusercontent.com/nf-core/test-datasets/refs/heads/epitopeprediction'
+    pipelines_testdata_base_path = 'https://raw.githubusercontent.com/nf-core/test-datasets/'
 }
 
 aws.client.anonymous = true // fixes S3 access issues on self-hosted runners


### PR DESCRIPTION
## Summary

- Extract protein IDs (ENSP, UniProt, RefSeq) directly from VCF CSQ annotations as fallback when BioMart lookup fails
- Add genome reference mapping to auto-detect Ensembl URL and dataset, removing the need for separate `--ensembl_dataset` parameter
- Fix several bugs related to metadata handling in FASTA output generation

## Changes

### Protein ID extraction from VCF
- Parse `ensp`, `swissprot`, `trembl`, `hgvsp`, and `refseq_match` fields from VEP annotations
- Merge VCF-derived protein IDs with BioMart results, using VCF as fallback
- Add error handling for BioMart API failures to gracefully fall back to VCF annotations

### Genome reference mapping
- Map genome names to Ensembl URLs and datasets automatically:
  - Human: `grch38`, `grch37`, `hg38`, `hg19` → `hsapiens_gene_ensembl`
  - Mouse: `grcm39`, `grcm38`, `mm39`, `mm10` → `mmusculus_gene_ensembl`
- Use Ensembl 102 archive for GRCm38/mm10 (last release with GRCm38 as primary)
- Support direct Ensembl URLs as fallback (defaults to human dataset)
- Remove `ensembl_dataset` parameter from config

### Bug fixes
- Fix metadata copying for transcripts with >10 variants (was using stale variable)
- Add `unwrap_to_string()` helper to handle nested list metadata from `get_metadata()`
- Add missing `global vcfConsequences` declaration in `generate_fasta_output()`
- Ensure `transcriptProteinTable` is always initialized even when BioMart fails

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
- [x] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
