### PR TITLE
Fix number of alleles in error message

### DIFF
--- a/modules/local/prepare_prediction_input/templates/prepare_prediction_input.py
+++ b/modules/local/prepare_prediction_input/templates/prepare_prediction_input.py
@@ -220,7 +220,7 @@ def main():
 
             # If NetMHC is specified, check if number of alleles doesnt exceed tool boundary
             if tool in ['netmhcpan','netmhciipan'] and len(args.alleles.split(";")) > MaxNumberOfAlleles.NETMHCPAN.value:
-                raise ValueError(f"Number of alleles {len(args.alleles.split(";"))} exceeds NetMHCpan limit of 50. Aborting..")
+                raise ValueError(f"Number of alleles {len(args.alleles.split(';'))} exceeds NetMHCpan limit of 50. Aborting..")
             # Special case for MHCflurry, which requires long format as input
             elif tool == "mhcflurry":
                 df_tool['allele'] = [tools_allele_input[tool].split(';')] * len(df_tool)

--- a/modules/local/prepare_prediction_input/templates/prepare_prediction_input.py
+++ b/modules/local/prepare_prediction_input/templates/prepare_prediction_input.py
@@ -220,7 +220,7 @@ def main():
 
             # If NetMHC is specified, check if number of alleles doesnt exceed tool boundary
             if tool in ['netmhcpan','netmhciipan'] and len(args.alleles.split(";")) > MaxNumberOfAlleles.NETMHCPAN.value:
-                raise ValueError(f"Number of alleles {len(args.alleles)} exceeds NetMHCpan limit of 50. Aborting..")
+                raise ValueError(f"Number of alleles {len(args.alleles.split(";"))} exceeds NetMHCpan limit of 50. Aborting..")
             # Special case for MHCflurry, which requires long format as input
             elif tool == "mhcflurry":
                 df_tool['allele'] = [tools_allele_input[tool].split(';')] * len(df_tool)


### PR DESCRIPTION
Fix number of alleles in error message.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
