### PR TITLE
Update nf-core documentation for NetMHCpan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#316](https://github.com/nf-core/epitopeprediction/pull/316) Added parameter `--biomart_dump` in `epaa.py` ([@SusiJo](https://github.com/SusiJo/)).
 - [#320](https://github.com/nf-core/epitopeprediction/pull/320) Set default genome reference to GRCh38 ([@jonasscheid](https://github.com/jonasscheid/)).
 - Remove `--ensembl_dataset` parameter; Ensembl dataset is now auto-detected from `--genome_reference` (supports human and mouse genomes, or direct Ensembl URL).
+- [#336](https://github.com/nf-core/epitopeprediction/pull/336) Added NetMHCpan 4.2 mode config file instructions to the nf-core usage documentation. ([@Kabooni](https://github.com/Kabooni)).
 
 ## 3.1.0 - Lustnau - 2025-10-22
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -126,6 +126,18 @@ The pipeline supports NetMHCpan 4.2bstatic and NetMHCIIpan 4.3e. If one of the e
 
 When using `conda`, the parameter `--netmhc_system` must also be specified if the default value `linux` is not applicable.
 
+NetMHCpan 4.2 supports different prediction modes. We strongly recommend using the default mode, but if necessary, the other modes can be selected with a custom config file.
+
+The antigen presentation mode is selected with `-mode 0`, the pathogen mode with `-mode 1` and the neoepitope mode with `-mode 2` in the module arguments. The config file can look like this:
+
+```
+process {
+    withName: NETMHCPAN {
+        ext.args = '-mode <1|2>'
+    }
+}
+```
+
 > [!IMPORTANT]
 > Only the specific versions `netMHCpan-4.2bstatic.Linux.tar.gz` and `netMHCIIpan-4.3e.Linux.tar.gz` are supported, as the pipeline validates these tarballs via checksum to ensure integrity.
 


### PR DESCRIPTION
## Summary
Add config file instructions for the different NetMHCpan 4.2 modes (antigen presentation, pathogen, neoepitope in the nf-core usage documentation.


## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
