### PR TITLE
Allow integer and string types in sample column of samplesheet

### DIFF
--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -8,10 +8,17 @@
         "type": "object",
         "properties": {
             "sample": {
-                "type": "string",
-                "pattern": "^\\S+$",
+                "anyOf": [
+                    {
+                        "type": "integer"
+                    },
+                    {
+                        "type": "string",
+                        "pattern": "^\\S+$"
+                    }
+                ],
                 "errorMessage": "Sample name must be provided and cannot contain spaces",
-                "description": "Custom sample name. This entry will be identical for multiple sequencing libraries/runs from the same sample.",
+                "description": "Custom sample name. This entry will be identical for multiple sequencing libraries/runs from the same sample. Can be an integer or a string without spaces.",
                 "meta": ["id"]
             },
             "alleles": {


### PR DESCRIPTION
The sample column in schema_input.json previously only accepted strings. This change uses anyOf to accept both integer and string types, enabling users to use numeric sample identifiers without quoting them.

https://claude.ai/code/session_01CzbyqWjRxPtVnX5YQBEMzn

<!--
# nf-core/epitopeprediction pull request

Many thanks for contributing to nf-core/epitopeprediction!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
