### PR TITLE
fix: VARIANT_SPLIT transpose compat with Nextflow 25.x

### DIFF
--- a/workflows/epitopeprediction.nf
+++ b/workflows/epitopeprediction.nf
@@ -138,6 +138,7 @@ workflow EPITOPEPREDICTION {
     // decide between the split_by_variants and snpsift_split (by chromosome)
     if (params.split_by_variants) {
         VARIANT_SPLIT( ch_samples_uncompressed.variant )
+            .splitted
             .set { ch_split_variants }
         ch_versions = ch_versions.mix( VARIANT_SPLIT.out.versions )
     }


### PR DESCRIPTION
## Summary
- Fixes `Missing process or function transpose([DataflowStream[?], DataflowStream[?]])` when running with `--split_by_variants` on Nextflow >=24.x
- Root cause: `VARIANT_SPLIT(...).set { ch_split_variants }` captures the entire `ChannelOut` object (both `splitted` and `versions` channels) instead of selecting the single `splitted` channel
- Adds `.splitted` selector before `.set`, matching the pattern already used by `SNPSIFT_SPLIT` in the else branch

## Test plan
- [ ] Run with `--split_by_variants --split_by_variants_size <N>` on Nextflow 25.x and verify the pipeline completes without transpose errors
- [ ] Run without `--split_by_variants` to confirm no regression on the SNPSIFT_SPLIT code path

🤖 Generated with [Claude Code](https://claude.com/claude-code)