### PR TITLE
Bump Python container from 3.11 to 3.14 in SPLIT_PEPTIDES and VARIANT_SPLIT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#331](https://github.com/nf-core/epitopeprediction/pull/331) Fixed Nextflow strict syntax lint errors ([@jonasscheid](https://github.com/jonasscheid/))
 - [#330](https://github.com/nf-core/epitopeprediction/pull/330) Extract protein IDs from VCF annotations and add genome reference mappings [@axelwalter](https://github.com/axelwalter)
+- [#348](https://github.com/nf-core/epitopeprediction/pull/348) Bumped Python container from 3.11 to 3.14 in SPLIT_PEPTIDES and VARIANT_SPLIT ([@jonasscheid](https://github.com/jonasscheid/))
 
 ### `Dependencies`
 

--- a/modules/local/split_peptides/environment.yml
+++ b/modules/local/split_peptides/environment.yml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - conda-forge::python=3.11.0
+  - conda-forge::python=3.14.3

--- a/modules/local/split_peptides/main.nf
+++ b/modules/local/split_peptides/main.nf
@@ -4,8 +4,8 @@ process SPLIT_PEPTIDES {
 
     // conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/python:3.11' :
-        'biocontainers/python:3.11' }"
+        'https://depot.galaxyproject.org/singularity/python:3.14' :
+        'biocontainers/python:3.14' }"
 
     input:
     tuple val(meta), path(tsv)

--- a/modules/local/variant_split/environment.yml
+++ b/modules/local/variant_split/environment.yml
@@ -2,4 +2,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - conda-forge::python=3.11.0
+  - conda-forge::python=3.14.3

--- a/modules/local/variant_split/main.nf
+++ b/modules/local/variant_split/main.nf
@@ -3,8 +3,8 @@ process VARIANT_SPLIT {
 
     // conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/python:3.11' :
-        'biocontainers/python:3.11' }"
+        'https://depot.galaxyproject.org/singularity/python:3.14' :
+        'biocontainers/python:3.14' }"
 
     input:
     tuple val(meta), path(input_file)

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -28,7 +28,7 @@
                     "snpsift": 4.3
                 },
                 "SPLIT_PEPTIDES": {
-                    "python": "3.11.10"
+                    "python": "3.14.3"
                 },
                 "SUMMARIZE_RESULTS": {
                     "python": "3.11.5"

--- a/tests/grch37.nf.test.snap
+++ b/tests/grch37.nf.test.snap
@@ -29,7 +29,7 @@
                     "snpsift": 4.3
                 },
                 "SPLIT_PEPTIDES": {
-                    "python": "3.11.10"
+                    "python": "3.14.3"
                 },
                 "SUMMARIZE_RESULTS": {
                     "python": "3.11.5"
@@ -253,7 +253,7 @@
                     "snpsift": 4.3
                 },
                 "SPLIT_PEPTIDES": {
-                    "python": "3.11.10"
+                    "python": "3.14.3"
                 },
                 "SUMMARIZE_RESULTS": {
                     "python": "3.11.5"

--- a/tests/mhcflurry.nf.test.snap
+++ b/tests/mhcflurry.nf.test.snap
@@ -25,7 +25,7 @@
                     "snpsift": 4.3
                 },
                 "SPLIT_PEPTIDES": {
-                    "python": "3.11.10"
+                    "python": "3.14.3"
                 },
                 "SUMMARIZE_RESULTS": {
                     "python": "3.11.5"

--- a/tests/mhcnuggets.nf.test.snap
+++ b/tests/mhcnuggets.nf.test.snap
@@ -30,7 +30,7 @@
                     "snpsift": 4.3
                 },
                 "SPLIT_PEPTIDES": {
-                    "python": "3.11.10"
+                    "python": "3.14.3"
                 },
                 "SUMMARIZE_RESULTS": {
                     "python": "3.11.5"

--- a/tests/netmhcpan.nf.test.snap
+++ b/tests/netmhcpan.nf.test.snap
@@ -12,7 +12,7 @@
                     "NetMHCpan": "4.2b"
                 },
                 "SPLIT_PEPTIDES": {
-                    "python": "3.11.10"
+                    "python": "3.14.3"
                 },
                 "SUMMARIZE_RESULTS": {
                     "python": "3.11.5"

--- a/tests/norm.nf.test.snap
+++ b/tests/norm.nf.test.snap
@@ -32,7 +32,7 @@
                     "snpsift": 4.3
                 },
                 "SPLIT_PEPTIDES": {
-                    "python": "3.11.10"
+                    "python": "3.14.3"
                 },
                 "SUMMARIZE_RESULTS": {
                     "python": "3.11.5"

--- a/tests/offline.nf.test.snap
+++ b/tests/offline.nf.test.snap
@@ -29,7 +29,7 @@
                     "snpsift": 4.3
                 },
                 "SPLIT_PEPTIDES": {
-                    "python": "3.11.10"
+                    "python": "3.14.3"
                 },
                 "SUMMARIZE_RESULTS": {
                     "python": "3.11.5"
@@ -249,7 +249,7 @@
                     "snpsift": 4.3
                 },
                 "SPLIT_PEPTIDES": {
-                    "python": "3.11.10"
+                    "python": "3.14.3"
                 },
                 "SUMMARIZE_RESULTS": {
                     "python": "3.11.5"

--- a/tests/peptides.nf.test.snap
+++ b/tests/peptides.nf.test.snap
@@ -14,7 +14,7 @@
                 },
                 "mhcnuggets": "2.4.0",
                 "SPLIT_PEPTIDES": {
-                    "python": "3.11.10"
+                    "python": "3.14.3"
                 },
                 "SUMMARIZE_RESULTS": {
                     "python": "3.11.5"

--- a/tests/proteins.nf.test.snap
+++ b/tests/proteins.nf.test.snap
@@ -18,7 +18,7 @@
                 },
                 "mhcnuggets": "2.4.0",
                 "SPLIT_PEPTIDES": {
-                    "python": "3.11.10"
+                    "python": "3.14.3"
                 },
                 "SUMMARIZE_RESULTS": {
                     "python": "3.11.5"

--- a/tests/wide_format_output.nf.test.snap
+++ b/tests/wide_format_output.nf.test.snap
@@ -14,7 +14,7 @@
                 },
                 "mhcnuggets": "2.4.0",
                 "SPLIT_PEPTIDES": {
-                    "python": "3.11.10"
+                    "python": "3.14.3"
                 },
                 "SUMMARIZE_RESULTS": {
                     "python": "3.11.5"


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nf-test test`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.

## Description of changes

Bumps the `biocontainers/python` container tag from `3.11` to `3.14` in `SPLIT_PEPTIDES` and `VARIANT_SPLIT` modules. These are the only two modules using the bare Python container. Addresses CI failures where `quay.io/biocontainers/python:3.11` returned 502 errors (older tags are less reliably cached on quay.io).

Updated all test snapshots to reflect the new Python version (`3.11.10` → `3.14.3`).

## Test plan

- [x] All test snapshots updated for new Python version in SPLIT_PEPTIDES
- [x] CI nf-test pipeline tests