### PR TITLE
Fix NetMHCIIpan mouse class II allele conversion and column parsing for v4.3 output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- Fixed NetMHCIIpan mouse class II allele conversion: `H2-AA*b/AB*b` now maps to `H-2-IAb` (and `H2-EA*d/EB*d` to `H-2-IEd`) instead of the invalid `H-2-AAb-ABb` ([@jonasscheid](https://github.com/jonasscheid/))
 - [#349](https://github.com/nf-core/epitopeprediction/pull/349) Fixed MultiQC stats mismatch: use per-peptide binder counts, fix unsupported count formula, fix netmhcpan multi-allele column parsing ([@jonasscheid](https://github.com/jonasscheid/))
 - [#331](https://github.com/nf-core/epitopeprediction/pull/331) Fixed Nextflow strict syntax lint errors ([@jonasscheid](https://github.com/jonasscheid/))
 - [#330](https://github.com/nf-core/epitopeprediction/pull/330) Extract protein IDs from VCF annotations and add genome reference mappings [@axelwalter](https://github.com/axelwalter)

--- a/modules/local/merge_predictions/templates/merge_predictions.py
+++ b/modules/local/merge_predictions/templates/merge_predictions.py
@@ -235,17 +235,21 @@ class PredictionResult:
     def _format_netmhciipan_prediction(self) -> pd.DataFrame:
         """
         Read in netmhciipan prediction output and extract the columns
-        `Peptide,Rank_EL,Score_BA` for multiple alleles (or Rank_BA when use_ba_rank is True).
+        `Peptide,Rank,Score_BA` for multiple alleles (or Rank_BA when use_ba_rank is True).
+        NetMHCIIpan 4.3 xls uses `Rank` for the EL percentile and `Rank_BA` for BA percentile;
+        multi-allele files are handled by pandas auto-suffixing duplicate columns as `.1`, `.2` …
         """
         # Map with allele index to allele name. NetMHCIIpan sorts alleles alphabetically
         alleles_dict = {i: allele for i, allele in enumerate(self.alleles)}
         # Read the file into a DataFrame with no headers initially
         df = pd.read_csv(self.file_path, sep='\t', skiprows=1)
         # Extract Peptide, percentile rank, binding affinity
-        # Select either Rank_BA (BA_Rank) or Rank_EL (EL_Rank) based on use_ba_rank flag
-        rank_metric = 'BA' if self.use_ba_rank else 'EL'
-        rank_column = f'Rank_{rank_metric}'
-        df = df[df.columns[df.columns.str.contains(f'Peptide|{rank_column}|Score_BA')]]
+        # Select either Rank_BA (BA percentile) or Rank (EL percentile) based on use_ba_rank flag
+        rank_column = 'Rank_BA' if self.use_ba_rank else 'Rank'
+        # Full-match so `Rank` does not accidentally pick up `Rank_BA` as a substring,
+        # while still matching pandas-suffixed duplicates in multi-allele mode (`Rank.1`, `Rank.2`, …).
+        keep_pattern = rf'Peptide|{rank_column}(\\.\\d+)?|Score_BA(\\.\\d+)?'
+        df = df[df.columns[df.columns.str.fullmatch(keep_pattern)]]
 
         df = df.rename(columns={'Peptide': self.peptide_col_name, rank_column: f'{rank_column}.0', 'Score_BA': 'Score_BA.0'})
         # to longformat based on .0|1|2..

--- a/modules/local/netmhciipan/main.nf
+++ b/modules/local/netmhciipan/main.nf
@@ -20,12 +20,20 @@ process NETMHCIIPAN {
     }
     def args    = task.ext.args ?: ''
     def prefix  = task.ext.prefix ?: "${meta.id}"
-    // Adjust for netMHCIIpan allele format (e.g. DRB1_0101, HLA-DPA10103-DPB10101)
+    // Adjust for netMHCIIpan allele format (e.g. DRB1_0101, HLA-DPA10103-DPB10101, H-2-IAb)
     def alleles = meta.alleles_supported.tokenize(';')
                     .collect { allele ->
-                        allele.contains('DRB') ?
-                            allele.replace('*', '_').replace(':', '').replace('HLA-', '') :
+                        if (allele.contains('DRB')) {
+                            // HLA-DRB1*01:01 -> DRB1_0101
+                            allele.replace('*', '_').replace(':', '').replace('HLA-', '')
+                        } else if (allele.startsWith('H2-') && allele.contains('/')) {
+                            // mhcgnomes mouse class II canonical form is H2-<X>A*<Y>/<X>B*<Y>
+                            // (locus X = A or E, haplotype Y = b/d/k/...). NetMHCIIpan wants H-2-I<X><Y>.
+                            "H-2-I${allele[3]}${allele.substring(allele.lastIndexOf('*') + 1)}"
+                        } else {
+                            // HLA-DPA1*01:03/DPB1*04:01 -> HLA-DPA10103-DPB10401
                             allele.replace('*', '').replace(':', '').replace('/','-').replace('H2','H-2')
+                        }
                     }.join(',')
 
     """


### PR DESCRIPTION
<!--
# nf-core/epitopeprediction pull request

Many thanks for contributing to nf-core/epitopeprediction!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
-->

## Description of changes

This PR fixes two defects in the NetMHCIIpan path that together broke mouse class II prediction end-to-end.

### 1. Mouse class II allele conversion (`modules/local/netmhciipan/main.nf`)

`mhcgnomes` normalises `H-2-IAb` to the canonical form `H2-AA*b/AB*b` (and similarly `H-2-IEd` → `H2-EA*d/EB*d`), which is the form stored in `assets/supported_alleles.json`. The previous conversion closure applied generic character replacements and produced the invalid string `H-2-AAb-ABb`, which NetMHCIIpan does not recognise.

The closure now detects the mhcgnomes mouse class II canonical form (`startsWith('H2-') && contains('/')`) and reconstructs the short form NetMHCIIpan expects:

- `H2-AA*b/AB*b` → `H-2-IAb`
- `H2-EA*d/EB*d` → `H-2-IEd`

Human `HLA-DRB*` and `HLA-DPA/DPB/DQA/DQB` paths are preserved; the mouse `H2-EB*b` lone-beta fallback is unchanged (no canonical NetMHCIIpan form exists). `mhcgnomes` was checked for a reverse serialiser (`Pair.to_string()`, `compact_string(include_species=True)`, `Serotype`) — none of them produce the `H-2-I<X><Y>` form, so the mapping has to be done at tool-call time.

### 2. `merge_predictions.py` column parsing for NetMHCIIpan 4.3 xls

The existing parser looked for a `Rank_EL` column, but NetMHCIIpan 4.3 xls output uses `Rank` for the EL percentile (and `Rank_BA` for the BA percentile). Any single-allele run failed with `KeyError: 'rank'` after the allele fix let NetMHCIIpan run at all. Changes:

- `rank_column` is now `'Rank_BA' if use_ba_rank else 'Rank'`.
- Column filter switched from `str.contains` → `str.fullmatch` with an optional `(\.\d+)?` suffix, so `Rank` doesn't accidentally capture `Rank_BA` as a substring, while multi-allele mode (where pandas auto-suffixes duplicate `Rank`, `Rank_BA`, `Score_BA` columns as `.1`, `.2`, …) is still handled.

### Verification

Tested on `nf-core` test data and on mouse MHC-II immunopeptidome data (B16-F10 tumor, H-2-IAb):

| Scenario | Result |
|---|---|
| `test_netmhciipan` profile (HLA-DRB1\*01:01, 10 peptides) | Completes end-to-end; realistic rank range (9.97–85.00) |
| Mouse class II, allele string `H-2-IAb` | Completes end-to-end; NetMHCIIpan xls header is `H-2-IAb`; 71.7% strong binders (Rank ≤ 2) on 4715 B16-F10 IP peptides |
| Mouse class II, allele string `H2-AA*b/AB*b` | Produces identical NetMHCIIpan xls as the `H-2-IAb` input |

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md) (n/a)
- [x] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository. (n/a)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`) — verified via `test_netmhciipan` and mouse B16-F10 run.
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated. (no user-facing parameter change)
- [ ] Output Documentation in `docs/output.md` is updated. (no output schema change)
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors). (no new tool/citation)