### PR TITLE
Accept 3- and 4-field HLA typings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-- Accept 3- and 4-field HLA typings by truncating to 2 fields via mhcgnomes (fixes [#350](https://github.com/nf-core/epitopeprediction/issues/350)) ([@jonasscheid](https://github.com/jonasscheid/))
+- [#352](https://github.com/nf-core/epitopeprediction/pull/352) Accept 3- and 4-field HLA typings by truncating to 2 fields via mhcgnomes (fixes [#350](https://github.com/nf-core/epitopeprediction/issues/350)) ([@jonasscheid](https://github.com/jonasscheid/))
 - Fixed NetMHCIIpan mouse class II allele conversion: `H2-AA*b/AB*b` now maps to `H-2-IAb` (and `H2-EA*d/EB*d` to `H-2-IEd`) instead of the invalid `H-2-AAb-ABb` ([@jonasscheid](https://github.com/jonasscheid/))
 - [#349](https://github.com/nf-core/epitopeprediction/pull/349) Fixed MultiQC stats mismatch: use per-peptide binder counts, fix unsupported count formula, fix netmhcpan multi-allele column parsing ([@jonasscheid](https://github.com/jonasscheid/))
 - [#331](https://github.com/nf-core/epitopeprediction/pull/331) Fixed Nextflow strict syntax lint errors ([@jonasscheid](https://github.com/jonasscheid/))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- Accept 3- and 4-field HLA typings by truncating to 2 fields via mhcgnomes (fixes [#350](https://github.com/nf-core/epitopeprediction/issues/350)) ([@jonasscheid](https://github.com/jonasscheid/))
 - Fixed NetMHCIIpan mouse class II allele conversion: `H2-AA*b/AB*b` now maps to `H-2-IAb` (and `H2-EA*d/EB*d` to `H-2-IEd`) instead of the invalid `H-2-AAb-ABb` ([@jonasscheid](https://github.com/jonasscheid/))
 - [#349](https://github.com/nf-core/epitopeprediction/pull/349) Fixed MultiQC stats mismatch: use per-peptide binder counts, fix unsupported count formula, fix netmhcpan multi-allele column parsing ([@jonasscheid](https://github.com/jonasscheid/))
 - [#331](https://github.com/nf-core/epitopeprediction/pull/331) Fixed Nextflow strict syntax lint errors ([@jonasscheid](https://github.com/jonasscheid/))

--- a/modules/local/prepare_prediction_input/templates/prepare_prediction_input.py
+++ b/modules/local/prepare_prediction_input/templates/prepare_prediction_input.py
@@ -134,7 +134,8 @@ class Utils:
                 alleles = [line.strip() for line in f.readlines()]
         else:
             alleles = allele_str.split(";")
-        alleles_normalized = [mhcgnomes.parse(allele).to_string() for allele in alleles]
+        # Truncate 3- and 4-field typings down to 2 fields so higher-resolution HLA inputs match the 2-field entries in assets/supported_alleles.json
+        alleles_normalized = [mhcgnomes.parse(allele).restrict_allele_fields(2).to_string() for allele in alleles]
 
         return alleles_normalized
 


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

## Description of changes

Fixes [#350](https://github.com/nf-core/epitopeprediction/issues/350).

Previously the pipeline only accepted 2-field HLA typings (e.g. `HLA-A*01:01`). If a user supplied a 3- or 4-field typing (`HLA-A*01:01:01`, `HLA-A*01:01:01:01`), the allele silently failed the membership check against `assets/supported_alleles.json` (which is 2-field only) and was dropped — often yielding `"No supported alleles for <tool> found. Aborting.."`.

This PR truncates any input allele with more than 2 fields down to 2 fields via `mhcgnomes.Allele.restrict_allele_fields(2)` inside `Utils.parse_alleles` in `modules/local/prepare_prediction_input/templates/prepare_prediction_input.py`. `mhcgnomes` is already a pipeline dependency, so no new packages are introduced. 2-field inputs are unchanged (truncation is a no-op).

Verification:
- `nf-test test tests/peptides.nf.test --profile=+docker` — PASSED (snapshot unchanged).
- `nf-test test tests/proteins.nf.test --profile=+docker` — PASSED (snapshot unchanged).
- End-to-end smoke run with `HLA-A*01:01:01:01;HLA-B*07:02:01` completed successfully; `prepare_prediction_input` wrote `{"mhcnuggets": "HLA-A*01:01;HLA-B*07:02"}` and mhcnuggets produced predictions for both truncated alleles.