### PR TITLE
Fix shuffled NetMHCpan/NetMHCIIpan allele labels in merged/best_allele output (fixes #358)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-- [#359](https://github.com/nf-core/epitopeprediction/pull/359) Fixed shuffled NetMHCIIpan allele labels in the merged/`best_allele` output by reading allele names from the xls header instead of assuming `sorted(meta.alleles)` order (fixes [#358](https://github.com/nf-core/epitopeprediction/issues/358)) ([@jonasscheid](https://github.com/jonasscheid/))
+- [#359](https://github.com/nf-core/epitopeprediction/pull/359) Fixed shuffled NetMHCpan/NetMHCIIpan allele labels in the merged/`best_allele` output by reading allele names from the xls header instead of assuming `sorted(meta.alleles)` order (fixes [#358](https://github.com/nf-core/epitopeprediction/issues/358)) ([@jonasscheid](https://github.com/jonasscheid/))
 - [#352](https://github.com/nf-core/epitopeprediction/pull/352) Accept 3- and 4-field HLA typings by truncating to 2 fields via mhcgnomes (fixes [#350](https://github.com/nf-core/epitopeprediction/issues/350)) ([@jonasscheid](https://github.com/jonasscheid/))
 - Fixed NetMHCIIpan mouse class II allele conversion: `H2-AA*b/AB*b` now maps to `H-2-IAb` (and `H2-EA*d/EB*d` to `H-2-IEd`) instead of the invalid `H-2-AAb-ABb` ([@jonasscheid](https://github.com/jonasscheid/))
 - [#349](https://github.com/nf-core/epitopeprediction/pull/349) Fixed MultiQC stats mismatch: use per-peptide binder counts, fix unsupported count formula, fix netmhcpan multi-allele column parsing ([@jonasscheid](https://github.com/jonasscheid/))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#359](https://github.com/nf-core/epitopeprediction/pull/359) Fixed shuffled NetMHCIIpan allele labels in the merged/`best_allele` output by reading allele names from the xls header instead of assuming `sorted(meta.alleles)` order (fixes [#358](https://github.com/nf-core/epitopeprediction/issues/358)) ([@jonasscheid](https://github.com/jonasscheid/))
 - [#352](https://github.com/nf-core/epitopeprediction/pull/352) Accept 3- and 4-field HLA typings by truncating to 2 fields via mhcgnomes (fixes [#350](https://github.com/nf-core/epitopeprediction/issues/350)) ([@jonasscheid](https://github.com/jonasscheid/))
 - Fixed NetMHCIIpan mouse class II allele conversion: `H2-AA*b/AB*b` now maps to `H-2-IAb` (and `H2-EA*d/EB*d` to `H-2-IEd`) instead of the invalid `H-2-AAb-ABb` ([@jonasscheid](https://github.com/jonasscheid/))
 - [#349](https://github.com/nf-core/epitopeprediction/pull/349) Fixed MultiQC stats mismatch: use per-peptide binder counts, fix unsupported count formula, fix netmhcpan multi-allele column parsing ([@jonasscheid](https://github.com/jonasscheid/))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-- [#359](https://github.com/nf-core/epitopeprediction/pull/359) Fixed shuffled NetMHCpan/NetMHCIIpan allele labels in the merged/`best_allele` output by reading allele names from the xls header instead of assuming `sorted(meta.alleles)` order (fixes [#358](https://github.com/nf-core/epitopeprediction/issues/358)) ([@jonasscheid](https://github.com/jonasscheid/))
+- [#359](https://github.com/nf-core/epitopeprediction/pull/359) Fixed shuffled NetMHCpan/NetMHCIIpan allele labels by reading allele names from the xls header (fixes [#358](https://github.com/nf-core/epitopeprediction/issues/358)) ([@jonasscheid](https://github.com/jonasscheid/))
 - [#352](https://github.com/nf-core/epitopeprediction/pull/352) Accept 3- and 4-field HLA typings by truncating to 2 fields via mhcgnomes (fixes [#350](https://github.com/nf-core/epitopeprediction/issues/350)) ([@jonasscheid](https://github.com/jonasscheid/))
 - Fixed NetMHCIIpan mouse class II allele conversion: `H2-AA*b/AB*b` now maps to `H-2-IAb` (and `H2-EA*d/EB*d` to `H-2-IEd`) instead of the invalid `H-2-AAb-ABb` ([@jonasscheid](https://github.com/jonasscheid/))
 - [#349](https://github.com/nf-core/epitopeprediction/pull/349) Fixed MultiQC stats mismatch: use per-peptide binder counts, fix unsupported count formula, fix netmhcpan multi-allele column parsing ([@jonasscheid](https://github.com/jonasscheid/))

--- a/modules/local/merge_predictions/templates/merge_predictions.py
+++ b/modules/local/merge_predictions/templates/merge_predictions.py
@@ -195,8 +195,14 @@ class PredictionResult:
         return df
 
     def _format_netmhcpan_prediction(self) -> pd.DataFrame:
-        # Map with allele index to allele name
-        alleles_dict = {i: allele for i, allele in enumerate(self.alleles)}
+        # Map output-column index to allele from the xls header row (one name per allele block), in
+        # NetMHCpan's output order. Reconstructing the order from sorted(meta.alleles) mislabels
+        # alleles whenever that sort diverges from NetMHCpan's — e.g. a stray space in a samplesheet
+        # allele ("; C*07:04") makes it sort first — leaving ranks correct but labels shuffled (#358).
+        # These names are normalized by mhcgnomes for all predictors in main().
+        with open(self.file_path) as f:
+            header_alleles = [allele.strip() for allele in f.readline().split('\t') if allele.strip()]
+        alleles_dict = dict(enumerate(header_alleles))
         # Read the file into a DataFrame with no headers initially
         df = pd.read_csv(self.file_path, sep='\t', skiprows=1)
         # Extract Peptide, percentile rank, binding affinity

--- a/modules/local/merge_predictions/templates/merge_predictions.py
+++ b/modules/local/merge_predictions/templates/merge_predictions.py
@@ -195,11 +195,7 @@ class PredictionResult:
         return df
 
     def _format_netmhcpan_prediction(self) -> pd.DataFrame:
-        # Map output-column index to allele from the xls header row (one name per allele block), in
-        # NetMHCpan's output order. Reconstructing the order from sorted(meta.alleles) mislabels
-        # alleles whenever that sort diverges from NetMHCpan's — e.g. a stray space in a samplesheet
-        # allele ("; C*07:04") makes it sort first — leaving ranks correct but labels shuffled (#358).
-        # These names are normalized by mhcgnomes for all predictors in main().
+        # Map column index to allele from the xls header (output order), not sorted(meta.alleles) (#358)
         with open(self.file_path) as f:
             header_alleles = [allele.strip() for allele in f.readline().split('\t') if allele.strip()]
         alleles_dict = dict(enumerate(header_alleles))
@@ -245,11 +241,7 @@ class PredictionResult:
         NetMHCIIpan 4.3 xls uses `Rank` for the EL percentile and `Rank_BA` for BA percentile;
         multi-allele files are handled by pandas auto-suffixing duplicate columns as `.1`, `.2` …
         """
-        # Map output-column index to allele from the xls header row (one name per allele block).
-        # NetMHCIIpan re-sorts alleles in its own name format, which diverges from the pipeline's
-        # mhcgnomes sort (e.g. DPB1*10:01 vs DPB1*107:01), so reconstructing the order from
-        # sorted(meta.alleles) mislabels alleles while leaving ranks correct (#358). These names are
-        # normalized by mhcgnomes for all predictors in main().
+        # Map column index to allele from the xls header (output order), not sorted(meta.alleles) (#358)
         with open(self.file_path) as f:
             header_alleles = [allele.strip() for allele in f.readline().split('\t') if allele.strip()]
         alleles_dict = dict(enumerate(header_alleles))

--- a/modules/local/merge_predictions/templates/merge_predictions.py
+++ b/modules/local/merge_predictions/templates/merge_predictions.py
@@ -239,8 +239,14 @@ class PredictionResult:
         NetMHCIIpan 4.3 xls uses `Rank` for the EL percentile and `Rank_BA` for BA percentile;
         multi-allele files are handled by pandas auto-suffixing duplicate columns as `.1`, `.2` …
         """
-        # Map with allele index to allele name. NetMHCIIpan sorts alleles alphabetically
-        alleles_dict = {i: allele for i, allele in enumerate(self.alleles)}
+        # Map output-column index to allele from the xls header row (one name per allele block).
+        # NetMHCIIpan re-sorts alleles in its own name format, which diverges from the pipeline's
+        # mhcgnomes sort (e.g. DPB1*10:01 vs DPB1*107:01), so reconstructing the order from
+        # sorted(meta.alleles) mislabels alleles while leaving ranks correct (#358). These names are
+        # normalized by mhcgnomes for all predictors in main().
+        with open(self.file_path) as f:
+            header_alleles = [allele.strip() for allele in f.readline().split('\t') if allele.strip()]
+        alleles_dict = dict(enumerate(header_alleles))
         # Read the file into a DataFrame with no headers initially
         df = pd.read_csv(self.file_path, sep='\t', skiprows=1)
         # Extract Peptide, percentile rank, binding affinity


### PR DESCRIPTION
## Description

Fixes #358.

`MERGE_PREDICTIONS` reconstructed which allele each NetMHC output column belonged to from `sorted(meta.alleles)`. This is wrong whenever the pipeline's sort order diverges from the predictor's output column order: the rank/BA values (tied to their column position) stay correct, but the allele labels — and the downstream `best_allele` — get shuffled. Two real triggers:

- **NetMHCIIpan (class II):** it writes allele columns sorted in its **own** allele-name format, which strips the `:` (`DPB1*10:01` → `DPB11001`). Combined with variable-width first fields (`10` vs `107`), the `:` (ASCII 58, sorts after digits) flips the order relative to the pipeline's mhcgnomes sort.
- **NetMHCpan (class I):** a stray space in a samplesheet allele (e.g. `...;C*07:01; C*07:04`) makes `' C*07:04'` sort first (space = ASCII 32), rotating the whole column→allele mapping by one.

The fix reads the authoritative allele order from the xls header row (each predictor labels every allele block there) instead of assuming `sorted(meta.alleles)`. This is robust to both triggers above and also fixes a latent misalignment when some requested alleles are unsupported by the predictor.

Verified end-to-end with real NetMHCIIpan 4.3 (divergent `DPB1*10:01` / `DPB1*107:01`) and real NetMHCpan 4.2 (the reported spaced-allele case): every allele now maps to its correct rank and `best_allele` is correct.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
