### PR TITLE
Bump nf-schema plugin to 2.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#336](https://github.com/nf-core/epitopeprediction/pull/336) Added NetMHCpan 4.2 mode config file instructions to the nf-core usage documentation. ([@Kabooni](https://github.com/Kabooni)).
 - [#346](https://github.com/nf-core/epitopeprediction/issues/346) Replace `CAT_CAT` with `FIND_CONCATENATE` to fix output filename collisions ([@jonasscheid](https://github.com/jonasscheid/)).
 - Bump nf-core modules and subworkflows to latest ([@jonasscheid](https://github.com/jonasscheid/)).
+- [#361](https://github.com/nf-core/epitopeprediction/pull/361) Bump `nf-schema` plugin to 2.7.2 ([@jonasscheid](https://github.com/jonasscheid/)).
 
 ## 3.1.0 - Lustnau - 2025-10-22
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -367,7 +367,7 @@ manifest {
 
 // Nextflow plugins
 plugins {
-    id 'nf-schema@2.5.1' // Validation of pipeline parameters and creation of an input channel from a sample sheet
+    id 'nf-schema@2.7.2' // Validation of pipeline parameters and creation of an input channel from a sample sheet
     id 'nf-co2footprint@1.0.0' // Trace and report energy consumption in CO2-equivalents
 }
 


### PR DESCRIPTION
## Description

Bumps the `nf-schema` Nextflow plugin from `2.5.1` to `2.7.2` (latest release) in `nextflow.config`.

This is a plugin version bump only — no pipeline code changes. The `nf-co2footprint` plugin is left untouched. The bundled `utils_nfschema_plugin` subworkflow test config already references `nf-schema@2.7.2`, so this aligns the pipeline with the version already exercised by the subworkflow tests.

CI should confirm compatibility of parameter validation and samplesheet input-channel creation with the new plugin version.

## Changes

- `nextflow.config`: `nf-schema@2.5.1` → `nf-schema@2.7.2`
- `CHANGELOG.md`: added entry under the `v3.2.0dev` `Changed` section