### PR TITLE
Fix inverted `--proteome_reference` self-filtering (fixes #363)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#364](https://github.com/nf-core/epitopeprediction/pull/364) Fixed inverted `--proteome_reference` self-filtering that retained self-epitopes instead of removing them (fixes [#363](https://github.com/nf-core/epitopeprediction/issues/363)) ([@jonasscheid](https://github.com/jonasscheid/))
 - [#359](https://github.com/nf-core/epitopeprediction/pull/359) Fixed shuffled NetMHCpan/NetMHCIIpan allele labels by reading allele names from the xls header (fixes [#358](https://github.com/nf-core/epitopeprediction/issues/358)) ([@jonasscheid](https://github.com/jonasscheid/))
 - [#352](https://github.com/nf-core/epitopeprediction/pull/352) Accept 3- and 4-field HLA typings by truncating to 2 fields via mhcgnomes (fixes [#350](https://github.com/nf-core/epitopeprediction/issues/350)) ([@jonasscheid](https://github.com/jonasscheid/))
 - Fixed NetMHCIIpan mouse class II allele conversion: `H2-AA*b/AB*b` now maps to `H-2-IAb` (and `H2-EA*d/EB*d` to `H-2-IEd`) instead of the invalid `H-2-AAb-ABb` ([@jonasscheid](https://github.com/jonasscheid/))

--- a/bin/epaa.py
+++ b/bin/epaa.py
@@ -1160,8 +1160,8 @@ def __main__():
     if args.proteome_reference:
         fasta_dict = parse_fasta(args.proteome_reference)
         num_mutated_peptides_pre_filter = mutated_peptides_df.shape[0]
-        # filter out peptides found in reference proteome
-        mutated_peptides_df = mutated_peptides_df[mutated_peptides_df["sequence"].apply(lambda pep: any([pep in prot for prot in fasta_dict.values()]))]
+        # filter out peptides found in reference proteome (keep only peptides absent from every reference protein)
+        mutated_peptides_df = mutated_peptides_df[mutated_peptides_df["sequence"].apply(lambda pep: not any([pep in prot for prot in fasta_dict.values()]))]
         logger.info(f"Filtered out {num_mutated_peptides_pre_filter - mutated_peptides_df.shape[0]} peptides that were found in the reference proteome.")
         if mutated_peptides_df.empty:
             write_empty_files(args)


### PR DESCRIPTION
## Description

Fixes #363. The `--proteome_reference` self-filter used `any(pep in prot for prot in fasta_dict.values())` directly as the keep-mask in `bin/epaa.py`, so pandas boolean indexing **retained** variant-derived peptides that occur in the reference proteome and **dropped** the novel ones — the opposite of the parameter's purpose (and of the log line right below it). Added the missing `not` so self-epitopes present in the reference proteome are removed.

Note: no automated test is added here — the filter runs only in the variant path (`EPYTOPE_VARIANT_PREDICTION`), which would require a dedicated proteome-fasta fixture in `nf-core/test-datasets`.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/epitopeprediction/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/epitopeprediction _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
