### PR TITLE
Fix NetMHCpan buffer overflow crash

### DIFF
--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -128,7 +128,7 @@ jobs:
       fail-fast: false
       matrix:
         NXF_VER:
-          - "25.04.0"
+          - "25.10.4"
           - "latest-everything"
     steps:
       - name: Check out pipeline code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed`
 
 - [#368](https://github.com/nf-core/epitopeprediction/pull/368) Fixed NetMHCpan crashing with a buffer overflow when run from a long working directory ([@jonasscheid](https://github.com/jonasscheid/))
-- [#368](https://github.com/nf-core/epitopeprediction/pull/368) Aligned the NetMHCpan CI job to Nextflow `25.10.4`, as `nf-schema` 2.7.2 is unavailable on `25.04.0` ([@jonasscheid](https://github.com/jonasscheid/))
 - [#364](https://github.com/nf-core/epitopeprediction/pull/364) Fixed inverted `--proteome_reference` self-filtering that retained self-epitopes instead of removing them (fixes [#363](https://github.com/nf-core/epitopeprediction/issues/363)) ([@jonasscheid](https://github.com/jonasscheid/))
 - [#359](https://github.com/nf-core/epitopeprediction/pull/359) Fixed shuffled NetMHCpan/NetMHCIIpan allele labels by reading allele names from the xls header (fixes [#358](https://github.com/nf-core/epitopeprediction/issues/358)) ([@jonasscheid](https://github.com/jonasscheid/))
 - [#352](https://github.com/nf-core/epitopeprediction/pull/352) Accept 3- and 4-field HLA typings by truncating to 2 fields via mhcgnomes (fixes [#350](https://github.com/nf-core/epitopeprediction/issues/350)) ([@jonasscheid](https://github.com/jonasscheid/))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+- [#368](https://github.com/nf-core/epitopeprediction/pull/368) Fixed NetMHCpan crashing with a buffer overflow when run from a long working directory, and made the module fail loudly instead of silently producing no predictions ([@jonasscheid](https://github.com/jonasscheid/))
+- [#368](https://github.com/nf-core/epitopeprediction/pull/368) Aligned the NetMHCpan CI job to Nextflow `25.10.4`, as `nf-schema` 2.7.2 is unavailable on `25.04.0` ([@jonasscheid](https://github.com/jonasscheid/))
 - [#364](https://github.com/nf-core/epitopeprediction/pull/364) Fixed inverted `--proteome_reference` self-filtering that retained self-epitopes instead of removing them (fixes [#363](https://github.com/nf-core/epitopeprediction/issues/363)) ([@jonasscheid](https://github.com/jonasscheid/))
 - [#359](https://github.com/nf-core/epitopeprediction/pull/359) Fixed shuffled NetMHCpan/NetMHCIIpan allele labels by reading allele names from the xls header (fixes [#358](https://github.com/nf-core/epitopeprediction/issues/358)) ([@jonasscheid](https://github.com/jonasscheid/))
 - [#352](https://github.com/nf-core/epitopeprediction/pull/352) Accept 3- and 4-field HLA typings by truncating to 2 fields via mhcgnomes (fixes [#350](https://github.com/nf-core/epitopeprediction/issues/350)) ([@jonasscheid](https://github.com/jonasscheid/))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
-- [#368](https://github.com/nf-core/epitopeprediction/pull/368) Fixed NetMHCpan crashing with a buffer overflow when run from a long working directory, and made the module fail loudly instead of silently producing no predictions ([@jonasscheid](https://github.com/jonasscheid/))
+- [#368](https://github.com/nf-core/epitopeprediction/pull/368) Fixed NetMHCpan crashing with a buffer overflow when run from a long working directory ([@jonasscheid](https://github.com/jonasscheid/))
 - [#368](https://github.com/nf-core/epitopeprediction/pull/368) Aligned the NetMHCpan CI job to Nextflow `25.10.4`, as `nf-schema` 2.7.2 is unavailable on `25.04.0` ([@jonasscheid](https://github.com/jonasscheid/))
 - [#364](https://github.com/nf-core/epitopeprediction/pull/364) Fixed inverted `--proteome_reference` self-filtering that retained self-epitopes instead of removing them (fixes [#363](https://github.com/nf-core/epitopeprediction/issues/363)) ([@jonasscheid](https://github.com/jonasscheid/))
 - [#359](https://github.com/nf-core/epitopeprediction/pull/359) Fixed shuffled NetMHCpan/NetMHCIIpan allele labels by reading allele names from the xls header (fixes [#358](https://github.com/nf-core/epitopeprediction/issues/358)) ([@jonasscheid](https://github.com/jonasscheid/))

--- a/conf/test_netmhcpan.config
+++ b/conf/test_netmhcpan.config
@@ -6,10 +6,6 @@
  * to run a fast and simple test. Use as follows:
  *   nextflow run nf-core/epitopeprediction -profile test_netmhcpan,<docker/singularity> --outdir <OUTDIR>
  * -------------------------------------------------
- * nf-test creates nested work directories, which can exceed the max char number allowed by netmhcpan
- * use e.g.
- * bash -l -c "export NFT_WORKDIR=/tmp/nft && nf-test test tests/netmhcpan.nf.test --profile=+docker --update-snapshot"
- * to prevent this
  */
 
 process {
@@ -18,6 +14,11 @@ process {
         memory: '6.GB',
         time: '48.h'
     ]
+
+    // nf-test creates nested work directories, which exceed the path length netmhcpan can handle
+    withName: NETMHCPAN {
+        scratch = true
+    }
 }
 
 params {

--- a/modules/local/netmhcpan/main.nf
+++ b/modules/local/netmhcpan/main.nf
@@ -24,54 +24,38 @@ process NETMHCPAN {
 
     """
     # TEMPORARY DIAGNOSTIC BLOCK -- to be removed before this PR is un-drafted.
-    # netMHCpan-4.2 aborts with "*** buffer overflow detected ***" after printing
-    # "# Predict", exits 0 anyway (tcsh wrapper), so Nextflow only reports the
-    # missing *.xls. The probes below narrow down what triggers the overflow.
-    # NB: no `| head` anywhere below -- Nextflow runs this with `bash -ue -o pipefail`,
-    # so SIGPIPE on the producer aborts the whole script with exit 141.
-    echo "### env"
-    echo "PWD_LEN=\${#PWD}"
-    echo "TMPDIR=\${TMPDIR:-unset}"
-    ldd --version > ldd.txt 2>&1 || true
-    sed -n '1p' ldd.txt
-    echo "stack_limit=\$(ulimit -s)"
-    echo "### input"
-    echo "alleles=$alleles"
-    echo "n_peptides=\$(wc -l < $tsv)"
-    echo "max_peptide_len=\$(awk '{ if (length(\$0) > m) m = length(\$0) } END { print m }' $tsv)"
-    sed -n '1,3p' $tsv | cat -A
-    tail -2 $tsv | cat -A
+    # All netMHCpan stdout is redirected to files: Nextflow only shows the TAIL of
+    # .command.out, and the per-peptide table drowns the verdicts otherwise.
+    # NB: no `| head` anywhere -- scripts run under `bash -ue -o pipefail`, so
+    # SIGPIPE on the producer aborts the whole script with exit 141.
+    sw=\$(readlink -f netmhcpan)
+    in_abs=\$(readlink -f $tsv)
+    sw_size=\$(du -sh --dereference netmhcpan | cut -f1)
 
-    echo "### run 1: as-is"
-    netmhcpan/netMHCpan \
-        -p $tsv \
-        -a $alleles \
-        -xls \
-        -xlsfile ${prefix}_predicted_netmhcpan.xls \
-        $args && rc=0 || rc=\$?
-    echo "run1_exit=\$rc"
-    ls -l ${prefix}_predicted_netmhcpan.xls 2>&1 || echo "run1: NO XLS"
+    netmhcpan/netMHCpan -p $tsv -a $alleles -xls \
+        -xlsfile ${prefix}_predicted_netmhcpan.xls $args > run1.log 2>&1 && r1=0 || r1=\$?
 
     if [ ! -s ${prefix}_predicted_netmhcpan.xls ]; then
-        echo "software_dir_size=\$(du -sh --dereference netmhcpan | cut -f1)"
+        rm -rf /tmp/nmpA /tmp/nmpB
+        mkdir -p /tmp/nmpA /tmp/nmpB
 
-        echo "### probe A: short cwd, software + input as SYMLINKS (cheap)"
-        rm -rf /tmp/nmpA && mkdir -p /tmp/nmpA
-        ln -s "\$(readlink -f netmhcpan)" /tmp/nmpA/nm
-        ln -s "\$(readlink -f $tsv)" /tmp/nmpA/in.tsv
-        ( cd /tmp/nmpA \
-            && ./nm/netMHCpan -p in.tsv -a $alleles -xls -xlsfile probeA.out $args && rc=0 || rc=\$? \
-            ; echo "probeA_exit=\$rc" \
-            ; ls -l /tmp/nmpA/probeA.out 2>&1 || echo "probeA: NO OUTPUT" )
+        ln -s "\$sw" /tmp/nmpA/nm
+        ln -s "\$in_abs" /tmp/nmpA/in.tsv
+        ( cd /tmp/nmpA && ./nm/netMHCpan -p in.tsv -a $alleles -xls -xlsfile probeA.out $args ) > probeA.log 2>&1 && rA=0 || rA=\$?
 
-        echo "### probe B: short cwd, software COPIED, input symlinked"
-        rm -rf /tmp/nmpB && mkdir -p /tmp/nmpB
         cp -rL netmhcpan /tmp/nmpB/nm
-        ln -s "\$(readlink -f $tsv)" /tmp/nmpB/in.tsv
-        ( cd /tmp/nmpB \
-            && ./nm/netMHCpan -p in.tsv -a $alleles -xls -xlsfile probeB.out $args && rc=0 || rc=\$? \
-            ; echo "probeB_exit=\$rc" \
-            ; ls -l /tmp/nmpB/probeB.out 2>&1 || echo "probeB: NO OUTPUT" )
+        ln -s "\$in_abs" /tmp/nmpB/in.tsv
+        ( cd /tmp/nmpB && ./nm/netMHCpan -p in.tsv -a $alleles -xls -xlsfile probeB.out $args ) > probeB.log 2>&1 && rB=0 || rB=\$?
+
+        echo "===== VERDICTS ====="
+        echo "PWD_LEN=\${#PWD}"
+        echo "software_dir_size=\$sw_size"
+        echo "symlink_target_len=\${#sw}"
+        echo "run1(long cwd)      exit=\$r1 xls_bytes=\$(stat -c%s ${prefix}_predicted_netmhcpan.xls 2>/dev/null || echo 0)"
+        echo "probeA(symlinked sw) exit=\$rA out_bytes=\$(stat -c%s /tmp/nmpA/probeA.out 2>/dev/null || echo 0)"
+        echo "probeB(copied sw)    exit=\$rB out_bytes=\$(stat -c%s /tmp/nmpB/probeB.out 2>/dev/null || echo 0)"
+        echo "probeA tail: \$(tail -2 probeA.log | tr '\\n' ' ')"
+        echo "===================="
     fi
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/netmhcpan/main.nf
+++ b/modules/local/netmhcpan/main.nf
@@ -1,9 +1,6 @@
 process NETMHCPAN {
     label 'process_single'
     tag "${meta.id}"
-    // netMHCpan-4.2 overruns fixed-size buffers built from the working directory
-    // path and is aborted by glibc, so run it from a short scratch directory.
-    scratch true
 
     // conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?

--- a/modules/local/netmhcpan/main.nf
+++ b/modules/local/netmhcpan/main.nf
@@ -23,12 +23,55 @@ process NETMHCPAN {
     def alleles = meta.alleles_supported.tokenize(';').collect { allele -> allele.replace('*', '').replace('H2','H-2') }.join(',')
 
     """
+    # TEMPORARY DIAGNOSTIC BLOCK -- to be removed before this PR is un-drafted.
+    # netMHCpan-4.2 aborts with "*** buffer overflow detected ***" after printing
+    # "# Predict", exits 0 anyway (tcsh wrapper), so Nextflow only reports the
+    # missing *.xls. The probes below narrow down what triggers the overflow.
+    echo "### env"
+    echo "PWD=\$PWD"
+    echo "PWD_LEN=\${#PWD}"
+    echo "TMPDIR=\${TMPDIR:-unset}"
+    ldd --version 2>&1 | head -1
+    echo "stack_limit=\$(ulimit -s)"
+    echo "### input"
+    echo "alleles=$alleles"
+    echo "n_peptides=\$(wc -l < $tsv)"
+    echo "max_peptide_len=\$(awk '{ if (length(\$0) > m) m = length(\$0) } END { print m }' $tsv)"
+    head -3 $tsv | cat -A
+    tail -2 $tsv | cat -A
+
+    echo "### run 1: as-is"
     netmhcpan/netMHCpan \
         -p $tsv \
         -a $alleles \
         -xls \
         -xlsfile ${prefix}_predicted_netmhcpan.xls \
-        $args
+        $args && rc=0 || rc=\$?
+    echo "run1_exit=\$rc"
+    ls -l ${prefix}_predicted_netmhcpan.xls 2>&1 || echo "run1: NO XLS"
+
+    if [ ! -s ${prefix}_predicted_netmhcpan.xls ]; then
+        echo "### run 2: single peptide, same directory"
+        head -1 $tsv > one_peptide.txt
+        netmhcpan/netMHCpan -p one_peptide.txt -a $alleles -xls -xlsfile probe_one.out $args && rc=0 || rc=\$?
+        echo "run2_exit=\$rc"
+        ls -l probe_one.out 2>&1 || echo "run2: NO OUTPUT"
+
+        echo "### run 3: full input, short path (/tmp/nmp)"
+        rm -rf /tmp/nmp && mkdir -p /tmp/nmp
+        cp -rL netmhcpan /tmp/nmp/nm
+        cp $tsv /tmp/nmp/in.tsv
+        ( cd /tmp/nmp \
+            && ./nm/netMHCpan -p in.tsv -a $alleles -xls -xlsfile probe_short.out $args && rc=0 || rc=\$? \
+            ; echo "run3_exit=\$rc" \
+            ; ls -l /tmp/nmp/probe_short.out 2>&1 || echo "run3: NO OUTPUT" )
+
+        echo "### run 4: no -xls, stdout only"
+        netmhcpan/netMHCpan -p $tsv -a $alleles $args > probe_stdout.txt 2>&1 && rc=0 || rc=\$?
+        echo "run4_exit=\$rc"
+        echo "run4_stdout_lines=\$(wc -l < probe_stdout.txt)"
+        tail -5 probe_stdout.txt
+    fi
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/netmhcpan/main.nf
+++ b/modules/local/netmhcpan/main.nf
@@ -1,6 +1,9 @@
 process NETMHCPAN {
     label 'process_single'
     tag "${meta.id}"
+    // netMHCpan-4.2 overruns fixed-size buffers built from the working directory
+    // path and is aborted by glibc, so run it from a short scratch directory.
+    scratch true
 
     // conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
@@ -23,35 +26,12 @@ process NETMHCPAN {
     def alleles = meta.alleles_supported.tokenize(';').collect { allele -> allele.replace('*', '').replace('H2','H-2') }.join(',')
 
     """
-    # netMHCpan-4.2 builds internal paths from the current working directory into
-    # fixed-size buffers. From a long cwd -- which Nextflow work dirs always are --
-    # it overruns them and glibc aborts it ("*** buffer overflow detected ***").
-    # The tcsh wrapper still exits 0, so the only symptom is a missing .xls.
-    # Running from a short scratch dir avoids it; symlinks keep the ~195 MB tool
-    # directory from being copied per task.
-    scratch=\$(mktemp -d /tmp/netmhcpan.XXXXXX)
-    ln -s "\$(readlink -f netmhcpan)" "\$scratch/nm"
-    ln -s "\$(readlink -f $tsv)" "\$scratch/input.tsv"
-
-    (
-        cd "\$scratch"
-        ./nm/netMHCpan \
-            -p input.tsv \
-            -a $alleles \
-            -xls \
-            -xlsfile ${prefix}_predicted_netmhcpan.xls \
-            $args
-    )
-
-    # netMHCpan exits 0 even when it crashes, so check the output explicitly.
-    if [ ! -s "\$scratch/${prefix}_predicted_netmhcpan.xls" ]; then
-        echo "ERROR: netMHCpan produced no output for ${prefix}" >&2
-        rm -rf "\$scratch"
-        exit 1
-    fi
-
-    mv "\$scratch/${prefix}_predicted_netmhcpan.xls" .
-    rm -rf "\$scratch"
+    netmhcpan/netMHCpan \
+        -p $tsv \
+        -a $alleles \
+        -xls \
+        -xlsfile ${prefix}_predicted_netmhcpan.xls \
+        $args
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/netmhcpan/main.nf
+++ b/modules/local/netmhcpan/main.nf
@@ -27,17 +27,19 @@ process NETMHCPAN {
     # netMHCpan-4.2 aborts with "*** buffer overflow detected ***" after printing
     # "# Predict", exits 0 anyway (tcsh wrapper), so Nextflow only reports the
     # missing *.xls. The probes below narrow down what triggers the overflow.
+    # NB: no `| head` anywhere below -- Nextflow runs this with `bash -ue -o pipefail`,
+    # so SIGPIPE on the producer aborts the whole script with exit 141.
     echo "### env"
-    echo "PWD=\$PWD"
     echo "PWD_LEN=\${#PWD}"
     echo "TMPDIR=\${TMPDIR:-unset}"
-    ldd --version 2>&1 | head -1
+    ldd --version > ldd.txt 2>&1 || true
+    sed -n '1p' ldd.txt
     echo "stack_limit=\$(ulimit -s)"
     echo "### input"
     echo "alleles=$alleles"
     echo "n_peptides=\$(wc -l < $tsv)"
     echo "max_peptide_len=\$(awk '{ if (length(\$0) > m) m = length(\$0) } END { print m }' $tsv)"
-    head -3 $tsv | cat -A
+    sed -n '1,3p' $tsv | cat -A
     tail -2 $tsv | cat -A
 
     echo "### run 1: as-is"
@@ -52,7 +54,7 @@ process NETMHCPAN {
 
     if [ ! -s ${prefix}_predicted_netmhcpan.xls ]; then
         echo "### run 2: single peptide, same directory"
-        head -1 $tsv > one_peptide.txt
+        sed -n '1p' $tsv > one_peptide.txt
         netmhcpan/netMHCpan -p one_peptide.txt -a $alleles -xls -xlsfile probe_one.out $args && rc=0 || rc=\$?
         echo "run2_exit=\$rc"
         ls -l probe_one.out 2>&1 || echo "run2: NO OUTPUT"

--- a/modules/local/netmhcpan/main.nf
+++ b/modules/local/netmhcpan/main.nf
@@ -23,40 +23,35 @@ process NETMHCPAN {
     def alleles = meta.alleles_supported.tokenize(';').collect { allele -> allele.replace('*', '').replace('H2','H-2') }.join(',')
 
     """
-    # TEMPORARY DIAGNOSTIC BLOCK -- to be removed before this PR is un-drafted.
-    # All netMHCpan stdout is redirected to files: Nextflow only shows the TAIL of
-    # .command.out, and the per-peptide table drowns the verdicts otherwise.
-    # NB: no `| head` anywhere -- scripts run under `bash -ue -o pipefail`, so
-    # SIGPIPE on the producer aborts the whole script with exit 141.
-    sw=\$(readlink -f netmhcpan)
-    in_abs=\$(readlink -f $tsv)
-    sw_size=\$(du -sh --dereference netmhcpan | cut -f1)
+    # netMHCpan-4.2 builds internal paths from the current working directory into
+    # fixed-size buffers. From a long cwd -- which Nextflow work dirs always are --
+    # it overruns them and glibc aborts it ("*** buffer overflow detected ***").
+    # The tcsh wrapper still exits 0, so the only symptom is a missing .xls.
+    # Running from a short scratch dir avoids it; symlinks keep the ~195 MB tool
+    # directory from being copied per task.
+    scratch=\$(mktemp -d /tmp/netmhcpan.XXXXXX)
+    ln -s "\$(readlink -f netmhcpan)" "\$scratch/nm"
+    ln -s "\$(readlink -f $tsv)" "\$scratch/input.tsv"
 
-    netmhcpan/netMHCpan -p $tsv -a $alleles -xls \
-        -xlsfile ${prefix}_predicted_netmhcpan.xls $args > run1.log 2>&1 && r1=0 || r1=\$?
+    (
+        cd "\$scratch"
+        ./nm/netMHCpan \
+            -p input.tsv \
+            -a $alleles \
+            -xls \
+            -xlsfile ${prefix}_predicted_netmhcpan.xls \
+            $args
+    )
 
-    if [ ! -s ${prefix}_predicted_netmhcpan.xls ]; then
-        rm -rf /tmp/nmpA /tmp/nmpB
-        mkdir -p /tmp/nmpA /tmp/nmpB
-
-        ln -s "\$sw" /tmp/nmpA/nm
-        ln -s "\$in_abs" /tmp/nmpA/in.tsv
-        ( cd /tmp/nmpA && ./nm/netMHCpan -p in.tsv -a $alleles -xls -xlsfile probeA.out $args ) > probeA.log 2>&1 && rA=0 || rA=\$?
-
-        cp -rL netmhcpan /tmp/nmpB/nm
-        ln -s "\$in_abs" /tmp/nmpB/in.tsv
-        ( cd /tmp/nmpB && ./nm/netMHCpan -p in.tsv -a $alleles -xls -xlsfile probeB.out $args ) > probeB.log 2>&1 && rB=0 || rB=\$?
-
-        echo "===== VERDICTS ====="
-        echo "PWD_LEN=\${#PWD}"
-        echo "software_dir_size=\$sw_size"
-        echo "symlink_target_len=\${#sw}"
-        echo "run1(long cwd)      exit=\$r1 xls_bytes=\$(stat -c%s ${prefix}_predicted_netmhcpan.xls 2>/dev/null || echo 0)"
-        echo "probeA(symlinked sw) exit=\$rA out_bytes=\$(stat -c%s /tmp/nmpA/probeA.out 2>/dev/null || echo 0)"
-        echo "probeB(copied sw)    exit=\$rB out_bytes=\$(stat -c%s /tmp/nmpB/probeB.out 2>/dev/null || echo 0)"
-        echo "probeA tail: \$(tail -2 probeA.log | tr '\\n' ' ')"
-        echo "===================="
+    # netMHCpan exits 0 even when it crashes, so check the output explicitly.
+    if [ ! -s "\$scratch/${prefix}_predicted_netmhcpan.xls" ]; then
+        echo "ERROR: netMHCpan produced no output for ${prefix}" >&2
+        rm -rf "\$scratch"
+        exit 1
     fi
+
+    mv "\$scratch/${prefix}_predicted_netmhcpan.xls" .
+    rm -rf "\$scratch"
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/local/netmhcpan/main.nf
+++ b/modules/local/netmhcpan/main.nf
@@ -53,26 +53,25 @@ process NETMHCPAN {
     ls -l ${prefix}_predicted_netmhcpan.xls 2>&1 || echo "run1: NO XLS"
 
     if [ ! -s ${prefix}_predicted_netmhcpan.xls ]; then
-        echo "### run 2: single peptide, same directory"
-        sed -n '1p' $tsv > one_peptide.txt
-        netmhcpan/netMHCpan -p one_peptide.txt -a $alleles -xls -xlsfile probe_one.out $args && rc=0 || rc=\$?
-        echo "run2_exit=\$rc"
-        ls -l probe_one.out 2>&1 || echo "run2: NO OUTPUT"
+        echo "software_dir_size=\$(du -sh --dereference netmhcpan | cut -f1)"
 
-        echo "### run 3: full input, short path (/tmp/nmp)"
-        rm -rf /tmp/nmp && mkdir -p /tmp/nmp
-        cp -rL netmhcpan /tmp/nmp/nm
-        cp $tsv /tmp/nmp/in.tsv
-        ( cd /tmp/nmp \
-            && ./nm/netMHCpan -p in.tsv -a $alleles -xls -xlsfile probe_short.out $args && rc=0 || rc=\$? \
-            ; echo "run3_exit=\$rc" \
-            ; ls -l /tmp/nmp/probe_short.out 2>&1 || echo "run3: NO OUTPUT" )
+        echo "### probe A: short cwd, software + input as SYMLINKS (cheap)"
+        rm -rf /tmp/nmpA && mkdir -p /tmp/nmpA
+        ln -s "\$(readlink -f netmhcpan)" /tmp/nmpA/nm
+        ln -s "\$(readlink -f $tsv)" /tmp/nmpA/in.tsv
+        ( cd /tmp/nmpA \
+            && ./nm/netMHCpan -p in.tsv -a $alleles -xls -xlsfile probeA.out $args && rc=0 || rc=\$? \
+            ; echo "probeA_exit=\$rc" \
+            ; ls -l /tmp/nmpA/probeA.out 2>&1 || echo "probeA: NO OUTPUT" )
 
-        echo "### run 4: no -xls, stdout only"
-        netmhcpan/netMHCpan -p $tsv -a $alleles $args > probe_stdout.txt 2>&1 && rc=0 || rc=\$?
-        echo "run4_exit=\$rc"
-        echo "run4_stdout_lines=\$(wc -l < probe_stdout.txt)"
-        tail -5 probe_stdout.txt
+        echo "### probe B: short cwd, software COPIED, input symlinked"
+        rm -rf /tmp/nmpB && mkdir -p /tmp/nmpB
+        cp -rL netmhcpan /tmp/nmpB/nm
+        ln -s "\$(readlink -f $tsv)" /tmp/nmpB/in.tsv
+        ( cd /tmp/nmpB \
+            && ./nm/netMHCpan -p in.tsv -a $alleles -xls -xlsfile probeB.out $args && rc=0 || rc=\$? \
+            ; echo "probeB_exit=\$rc" \
+            ; ls -l /tmp/nmpB/probeB.out 2>&1 || echo "probeB: NO OUTPUT" )
     fi
 
     cat <<-END_VERSIONS > versions.yml

--- a/tests/netmhcpan.nf.test.snap
+++ b/tests/netmhcpan.nf.test.snap
@@ -63,7 +63,7 @@
                 "multiqc_binder_rank_distribution.txt:md5,ec90da915e1e675ba4783a1ef333f5d6",
                 "multiqc_binding_affinity_distribution.txt:md5,971dc7e590882902783bd650e38caf39",
                 "multiqc_citations.txt:md5,4c806e63a283ec1b7e78cdae3a923d4f",
-                "multiqc_peptide_binding_prediction_stats.txt:md5,f21634746a48cc909875f026c8dc470d"
+                "multiqc_peptide_binding_prediction_stats.txt:md5,9ae5d3bb44ec4905ce1ad78a4c114ea2"
             ]
         ],
         "meta": {


### PR DESCRIPTION
nf-test creates nested work directories, which exceed the path length netmhcpan can handle in CI